### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a **homelab infrastructure-as-code (IaC) / GitOps repository**. There is no runnable web application in this repo; it contains Kubernetes manifests (Flux-managed), Python automation scripts for Proxmox LXC provisioning, Docker Compose stacks for SDR feeders, and container image Dockerfiles.
+
+### Dev dependencies
+
+- **Python** (>=3.8): runtime dep `dnspython`, dev deps `coverage`, `flake8`, `flake8-html`, `unittest-xml-reporting`, `genbadge[all]`. Install via `pip install dnspython==2.2.1 coverage==7.8.0 unittest-xml-reporting==3.2.0 flake8==7.2.0 flake8-html==0.4.3 "genbadge[all]==1.1.3"`. Note: `pip install -e ".[dev]"` will fail because flit expects a `proxmox` Python module that does not exist; install deps directly instead.
+- **Node.js**: only used for `prettier` formatting. Install via `npm install`.
+
+### Running tests
+
+```bash
+# Python unit tests (two discovery roots)
+python3 -m unittest discover -s src -v
+python3 -m unittest discover -s scripts -v
+
+# Coverage (mirrors the npm python-coverage script but without manage.py)
+coverage erase && coverage run -m unittest discover -s src && coverage run --append -m unittest discover -s scripts && coverage report
+```
+
+A `config.ini` file (copied from `scripts/config.ini.example`) must exist at the repo root for the Python source modules to import successfully (the `Config()` class reads it at module load time).
+
+### Linting
+
+```bash
+# Python linting (project uses --exit-zero in CI, warnings are expected)
+flake8 --statistics src/ scripts/
+
+# Prettier formatting check (YAML, JSON, Markdown)
+npx prettier --check "**/*.{yaml,yml,json,md}"
+```
+
+### Key caveats
+
+- The `scripts/example.py` entry point requires a live Proxmox host (calls `pvesh`); it cannot be run locally.
+- The `scripts/lsio.py` system-info script queries hardware devices (`nvme`, `/proc/mdstat`, etc.) and will produce empty/error output outside a Proxmox host.
+- The Kubernetes manifests are declarative and reconciled by Flux on the actual clusters; there is no local `kubectl apply` workflow.
+- SDR Docker images require physical Raspberry Pi + USB SDR hardware to test end-to-end.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description 💬

Adds `AGENTS.md` with Cursor Cloud specific instructions for future cloud agents working in this repository.

### What's included

- Dev dependency installation notes (Python + Node.js)
- How to run tests (`unittest discover` for both `src/` and `scripts/` roots)
- Linting commands (`flake8`, `prettier`)
- Key caveats about the infra-as-code nature of the repo (no runnable web app, Proxmox scripts require live host, SDR images require physical hardware)
- Note about `config.ini` requirement for Python module imports

### Environment verification

All tooling was verified working:

- Python unit tests pass (2 tests across `src/` and `scripts/`)
- `flake8` linting runs successfully (pre-existing warnings only)
- `prettier` formatting check runs successfully
- `coverage` reporting works
- Python GHCR image scanner and Samba config generator execute correctly

Test output log:

[dev_environment_test_output.log](https://cursor.com/agents/bc-90957977-cbe1-4482-a917-b9e030200f0f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_environment_test_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90957977-cbe1-4482-a917-b9e030200f0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90957977-cbe1-4482-a917-b9e030200f0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

