### PR TITLE
feat(cert-manager): add cert-manager resources for TLS management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -120,6 +120,7 @@ updates:
   - "/clusters/production/apps"
   - "/clusters/production/apps/authelia-production"
   - "/clusters/production/apps/ceph-csi"
+  - "/clusters/production/apps/cert-manager"
   - "/clusters/production/apps/clutterstock"
   - "/clusters/production/apps/clutterstock-migrate"
   - "/clusters/production/apps/dex-example-app-production"

--- a/clusters/production/apps/cert-manager/cert-manager-helmrelease.yaml
+++ b/clusters/production/apps/cert-manager/cert-manager-helmrelease.yaml
@@ -1,0 +1,62 @@
+# cert-manager: TLS certificates for RabbitMQ, Traefik, and other in-cluster consumers.
+# Chart: https://github.com/cert-manager/cert-manager/tree/master/deploy/charts/cert-manager
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+spec:
+  interval: 30m
+  timeout: 15m
+  targetNamespace: cert-manager
+  install:
+    createNamespace: false
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: cert-manager
+      version: "v1.20.2"
+      sourceRef:
+        kind: HelmRepository
+        name: jetstack
+        namespace: cert-manager
+  values:
+    crds:
+      enabled: true
+    global:
+      commonLabels:
+        app.kubernetes.io/part-of: cert-manager-production
+    controller:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 256Mi
+    webhook:
+      resources:
+        requests:
+          cpu: 25m
+          memory: 32Mi
+        limits:
+          memory: 128Mi
+    cainjector:
+      resources:
+        requests:
+          cpu: 25m
+          memory: 64Mi
+        limits:
+          memory: 256Mi
+    startupapicheck:
+      resources:
+        requests:
+          cpu: 25m
+          memory: 32Mi
+        limits:
+          memory: 128Mi

--- a/clusters/production/apps/cert-manager/cert-manager-secrets.md
+++ b/clusters/production/apps/cert-manager/cert-manager-secrets.md
@@ -1,0 +1,65 @@
+# cert-manager credentials (production)
+
+TLS for cluster workloads uses **cert-manager** in namespace **`cert-manager`**. This directory ships a **`ClusterIssuer`** `letsencrypt-dns` that completes **ACME DNS-01** using **RFC2136** (TSIG), the same mechanism as nginx DNS challenges and Proxmox ACME when pointed at BIND / PowerDNS / similar.
+
+## 1. CA scope (what this issuer is for)
+
+- **Public Let’s Encrypt certificates** for DNS names under **`wsh.no`** that resolve publicly and pass HTTP-01/DNS-01 validation rules (no internal-only TLDs such as `*.svc.cluster.local`).
+- **Private / internal-only names** (for example pure in-cluster DNS) are **out of scope** for this `ClusterIssuer`; use a separate CA issuer or another secret workflow if you need those SANs.
+
+The `ClusterIssuer` solver is limited to the **`wsh.no`** zone via `spec.acme.solvers[].selector.dnsZones`.
+
+## 2. RFC2136 TSIG secret (required before certificates issue)
+
+Create a **TSIG key** on your authoritative DNS server (same style as for nginx or Proxmox), then store the shared secret in Kubernetes.
+
+Example (key name and secret must match [`clusterissuer-letsencrypt-dns.yaml`](clusterissuer-letsencrypt-dns.yaml)):
+
+```bash
+# Put the TSIG shared secret bytes in a local file using the format cert-manager expects for your algorithm
+# (see upstream RFC2136 docs), then:
+kubectl create secret generic rfc2136-tsig-wsh-no \
+  --namespace cert-manager \
+  --from-file=tsig-secret=./tsig-secret.key
+```
+
+cert-manager expects the key referenced by **`tsigSecretSecretRef.key`** (`tsig-secret` here) to hold the secret material in the format your DNS software documents (commonly raw key bytes or base64; match what cert-manager’s RFC2136 solver expects for your algorithm — see [cert-manager RFC2136](https://cert-manager.io/docs/configuration/acme/dns01/rfc2136/)).
+
+## 3. Edit the ClusterIssuer to match your environment
+
+1. **`spec.acme.email`** — Let’s Encrypt account contact; must be deliverable mail for expiry/security notices.
+2. **`spec.acme.solvers[].dns01.rfc2136.nameserver`** — Address of the DNS server that accepts **signed updates** for `wsh.no` (often the same host you configured for nginx RFC2136). Include port if not `53`, e.g. `10.0.0.1:53`.
+3. **`tsigKeyName`** — Exact TSIG key name on the server (trailing dot is conventional for absolute names).
+4. **`tsigAlgorithm`** — Must match the server (`HMACSHA256`, `HMACSHA512`, etc.).
+
+After changing the issuer or secret, watch challenges:
+
+```bash
+kubectl get clusterissuer letsencrypt-dns -o wide
+kubectl get certificate -A
+kubectl describe challenge -n rabbitmq-production
+```
+
+Staging directory (for dry-runs): `https://acme-staging-v02.api.letsencrypt.org/directory` — use a **different** `metadata.name` / `privateKeySecretRef` if you add a staging issuer so account keys do not collide.
+
+## 4. RabbitMQ bootstrap note
+
+`RabbitmqCluster` references `Secret` **`rabbitmq-tls`** before cert-manager has written it. Until **`Certificate` `rabbitmq-tls`** is **Ready**, RabbitMQ pods may stay in **ContainerCreating** (missing volume). Apply the TSIG secret and correct **`nameserver` / `tsigKeyName`** in [`clusterissuer-letsencrypt-dns.yaml`](clusterissuer-letsencrypt-dns.yaml) **before** or immediately after merging so the first issuance succeeds quickly.
+
+## 5. Verify RabbitMQ TLS after issuance
+
+Once `Certificate` `rabbitmq-tls` is **Ready** and the `Secret` `rabbitmq-tls` exists in `rabbitmq-production`:
+
+```bash
+kubectl get certificate rabbitmq-tls -n rabbitmq-production
+kubectl get secret rabbitmq-tls -n rabbitmq-production -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -subject -dates -ext subjectAltName
+```
+
+From a debug pod with `openssl` (or any host that can reach the broker on **5671**):
+
+```bash
+openssl s_client -connect rabbitmq.rabbitmq-production.svc.cluster.local:5671 \
+  -servername rabbitmq.wsh.no -brief </dev/null
+```
+
+The certificate is issued for **public** `wsh.no` names; clients must use a **hostname present in SAN** (for example `rabbitmq.wsh.no` as TLS server name) when they verify the chain. Connecting with only `*.svc.cluster.local` as the verify hostname will **not** match a Let’s Encrypt certificate.

--- a/clusters/production/apps/cert-manager/clusterissuer-letsencrypt-dns.yaml
+++ b/clusters/production/apps/cert-manager/clusterissuer-letsencrypt-dns.yaml
@@ -1,0 +1,27 @@
+# ACME DNS-01 via RFC2136 (TSIG dynamic updates), same operational model as nginx / Proxmox ACME.
+# Replace nameserver and tsigKeyName with values that match your authoritative DNS (see cert-manager-secrets.md).
+# The TSIG secret must exist in namespace cert-manager before certificates can issue.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-dns
+spec:
+  acme:
+    email: acme-notify@wsh.no
+    privateKeySecretRef:
+      name: clusterissuer-letsencrypt-dns-account-key
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+      - selector:
+          dnsZones:
+            - wsh.no
+        dns01:
+          rfc2136:
+            # RFC 5737 documentation address — replace with the host:port your DNS accepts updates on.
+            nameserver: 192.0.2.1:53
+            tsigAlgorithm: HMACSHA256
+            # TSIG key name as configured on the server (often ends with a trailing dot).
+            tsigKeyName: cert-manager-wsh-no.
+            tsigSecretSecretRef:
+              name: rfc2136-tsig-wsh-no
+              key: tsig-secret

--- a/clusters/production/apps/cert-manager/helmrepository.yaml
+++ b/clusters/production/apps/cert-manager/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: jetstack
+  namespace: cert-manager
+spec:
+  interval: 1h
+  url: https://charts.jetstack.io

--- a/clusters/production/apps/cert-manager/kustomization.yaml
+++ b/clusters/production/apps/cert-manager/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - cert-manager-helmrelease.yaml
+  - clusterissuer-letsencrypt-dns.yaml

--- a/clusters/production/apps/cert-manager/namespace.yaml
+++ b/clusters/production/apps/cert-manager/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+  labels:
+    app.kubernetes.io/part-of: cert-manager-production

--- a/clusters/production/apps/kustomization.yaml
+++ b/clusters/production/apps/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - namespace-platform-production.yaml
 - ceph-csi
+- cert-manager
 - traefik
 - authelia-production
 - headlamp-production

--- a/clusters/production/apps/rabbitmq-production/certificate-rabbitmq-tls.yaml
+++ b/clusters/production/apps/rabbitmq-production/certificate-rabbitmq-tls.yaml
@@ -1,0 +1,18 @@
+# Let’s Encrypt TLS for RabbitMQ listeners (AMQPS / management HTTPS) once ClusterIssuer letsencrypt-dns is Ready.
+# SANs are public wsh.no names; see rabbitmq-secrets.md for hostname verification vs in-cluster DNS.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: rabbitmq-tls
+  namespace: rabbitmq-production
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    app.kubernetes.io/part-of: rabbitmq-production
+spec:
+  secretName: rabbitmq-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-dns
+  dnsNames:
+    - rabbitmq.wsh.no
+    - rabbitmq.mgmt.wsh.no

--- a/clusters/production/apps/rabbitmq-production/kustomization.yaml
+++ b/clusters/production/apps/rabbitmq-production/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - https://github.com/rabbitmq/cluster-operator/releases/download/v2.20.1/cluster-operator.yml
   - messaging-topology-operator-no-namespace.yaml
   - namespace.yaml
+  - certificate-rabbitmq-tls.yaml
   - rabbitmq-cluster.yaml
   - topology-vhost-test-test.yaml
   - topology-user-test-api.yaml

--- a/clusters/production/apps/rabbitmq-production/networkpolicy-rabbitmq.yaml
+++ b/clusters/production/apps/rabbitmq-production/networkpolicy-rabbitmq.yaml
@@ -19,6 +19,8 @@ spec:
       protocol: TCP
     - port: 5672
       protocol: TCP
+    - port: 5671
+      protocol: TCP
     - port: 15672
       protocol: TCP
     - port: 25672
@@ -30,6 +32,8 @@ spec:
     ports:
     - port: 5672
       protocol: TCP
+    - port: 5671
+      protocol: TCP
   - from:
     - namespaceSelector:
         matchLabels:
@@ -38,4 +42,6 @@ spec:
     - port: 15672
       protocol: TCP
     - port: 5672
+      protocol: TCP
+    - port: 5671
       protocol: TCP

--- a/clusters/production/apps/rabbitmq-production/rabbitmq-cluster.yaml
+++ b/clusters/production/apps/rabbitmq-production/rabbitmq-cluster.yaml
@@ -72,6 +72,8 @@ spec:
                   runAsNonRoot: true
                   seccompProfile:
                     type: RuntimeDefault
+  tls:
+    secretName: rabbitmq-tls
   rabbitmq:
     additionalConfig: |
       loopback_users.guest = false

--- a/clusters/production/apps/rabbitmq-production/rabbitmq-secrets.md
+++ b/clusters/production/apps/rabbitmq-production/rabbitmq-secrets.md
@@ -45,3 +45,14 @@ Management plugin listens on **15672** inside the cluster (no public Ingress is 
 ## 4. Upgrading the messaging topology operator manifest
 
 `messaging-topology-operator-no-namespace.yaml` is the upstream **`messaging-topology-operator.yaml`** release asset with the **first `Namespace/rabbitmq-system` document removed**, so it can live in the same Kustomize build as **`cluster-operator.yml`** (which already defines that namespace). When bumping the topology operator version, re-download the release YAML, strip that first document, and replace the file.
+
+## 5. TLS (AMQPS / management)
+
+The cluster references **`spec.tls.secretName: rabbitmq-tls`**, populated by cert-manager **`Certificate`** [`certificate-rabbitmq-tls.yaml`](certificate-rabbitmq-tls.yaml) using **`ClusterIssuer`** `letsencrypt-dns` (RFC2136). Create the TSIG secret and fix the issuer nameserver/key name first — see [`../cert-manager/cert-manager-secrets.md`](../cert-manager/cert-manager-secrets.md).
+
+- **AMQPS** listens on **5671** when TLS is enabled (plain AMQP remains on **5672** unless you change listener config separately).
+- The issued certificate covers **`rabbitmq.wsh.no`** and **`rabbitmq.mgmt.wsh.no`**. Clients that verify TLS must use a **hostname present in the cert** (for example **`rabbitmq.wsh.no` as the server name**), not only `rabbitmq.rabbitmq-production.svc.cluster.local`, or hostname verification will fail against Let’s Encrypt.
+- After Flux applies changes, confirm the cert is **Ready**, then run the checks in cert-manager-secrets.md §5 (OpenSSL).
+
+Public **Ingress** for the management UI is not defined in this bundle; management stays cluster-reachable on **15672** unless you add routing separately.
+


### PR DESCRIPTION
- Introduced cert-manager configuration for managing TLS certificates in the production environment.
- Added a HelmRelease for cert-manager, enabling automated installation and updates.
- Created a ClusterIssuer for Let's Encrypt DNS-01 challenge using RFC2136 for dynamic updates.
- Documented cert-manager secrets management and operational procedures for issuing certificates.
- Updated RabbitMQ configuration to utilize the new TLS certificate for secure communication.

## Description 💬

<!--- Describe your changes in detail -->
