### PR TITLE
feat(cert-manager): introduce internal CA and trust management for Ra…

### DIFF
--- a/clusters/production/apps/cert-manager/bundle-wsh-internal-ca.yaml
+++ b/clusters/production/apps/cert-manager/bundle-wsh-internal-ca.yaml
@@ -1,0 +1,28 @@
+# trust-manager Bundle that distributes our internal CA (certificate-internal-ca.yaml) plus the
+# Mozilla public roots to every namespace labelled wsh.no/trust-bundle=true.
+#
+# Result: each labelled namespace gets a ConfigMap/wsh-internal-ca with key ca-bundle.crt containing
+# the full PEM chain. Workloads mount it at /etc/ssl/wsh/ca-bundle.crt and point SSL_CERT_FILE at it
+# (first consumer: clusters/production/apps/test-test/test-api-deployment.yaml — trusts the broker's
+# self-signed AMQPS/management cert from clusters/production/apps/rabbitmq-production/).
+#
+# Label a namespace with kubectl label ns <name> wsh.no/trust-bundle=true (or on the Namespace CR
+# under clusters/production/apps/<app>-<env>/namespace.yaml).
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: wsh-internal-ca
+  labels:
+    app.kubernetes.io/part-of: cert-manager-production
+spec:
+  sources:
+  - useDefaultCAs: true
+  - secret:
+      name: internal-ca
+      key: tls.crt
+  target:
+    configMap:
+      key: ca-bundle.crt
+    namespaceSelector:
+      matchLabels:
+        wsh.no/trust-bundle: "true"

--- a/clusters/production/apps/cert-manager/certificate-internal-ca.yaml
+++ b/clusters/production/apps/cert-manager/certificate-internal-ca.yaml
@@ -1,0 +1,23 @@
+# Internal CA for workloads that need a certificate valid for in-cluster DNS names (*.svc, *.svc.cluster.local)
+# which Let's Encrypt cannot sign. Signed by clusterissuer-selfsigned-bootstrap.yaml; consumed by
+# clusterissuer-internal-ca.yaml (which looks up this Secret in the cert-manager namespace by default
+# via --cluster-resource-namespace). First consumer: rabbitmq-production/certificate-rabbitmq-tls.yaml.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: internal-ca
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/part-of: cert-manager-production
+spec:
+  isCA: true
+  commonName: wsh-internal-ca
+  secretName: internal-ca
+  duration: 87600h    # 10y — cert-manager auto-renews at renewBefore (default ~1/3 of duration).
+  renewBefore: 17520h # 2y  — rotate before expiry without co-sign hassles.
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-bootstrap
+    kind: ClusterIssuer

--- a/clusters/production/apps/cert-manager/clusterissuer-internal-ca.yaml
+++ b/clusters/production/apps/cert-manager/clusterissuer-internal-ca.yaml
@@ -1,0 +1,12 @@
+# CA ClusterIssuer for in-cluster TLS where Let's Encrypt cannot issue (e.g. *.svc, *.svc.cluster.local).
+# Reads the CA key material from Secret internal-ca in the cert-manager namespace (see
+# certificate-internal-ca.yaml). cert-manager looks up ClusterIssuer ca.secretName in the
+# --cluster-resource-namespace, which defaults to the cert-manager install namespace.
+# Use clusterissuer-letsencrypt-dns.yaml for anything publicly exposed.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: internal-ca
+spec:
+  ca:
+    secretName: internal-ca

--- a/clusters/production/apps/cert-manager/clusterissuer-selfsigned-bootstrap.yaml
+++ b/clusters/production/apps/cert-manager/clusterissuer-selfsigned-bootstrap.yaml
@@ -1,0 +1,9 @@
+# Bootstrap ClusterIssuer: signs the internal-ca root Certificate (see certificate-internal-ca.yaml).
+# Not used directly by application Certificates — use clusterissuer-internal-ca.yaml for in-cluster DNS names
+# and clusterissuer-letsencrypt-dns.yaml for public wsh.no names.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-bootstrap
+spec:
+  selfSigned: {}

--- a/clusters/production/apps/cert-manager/install/kustomization.yaml
+++ b/clusters/production/apps/cert-manager/install/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - namespace.yaml
 - helmrepository.yaml
 - cert-manager-helmrelease.yaml
+- trust-manager-helmrelease.yaml

--- a/clusters/production/apps/cert-manager/install/trust-manager-helmrelease.yaml
+++ b/clusters/production/apps/cert-manager/install/trust-manager-helmrelease.yaml
@@ -1,0 +1,55 @@
+# trust-manager: distributes TLS trust bundles (Mozilla public roots + our internal CA) to namespaces
+# via the Bundle CRD. Installed in the same cert-manager-install Flux Kustomization as cert-manager
+# so the Bundle CRD exists before ../bundle-wsh-internal-ca.yaml reconciles against ./clusters/production.
+#
+# Chart: https://github.com/cert-manager/trust-manager/tree/main/deploy/charts/trust-manager
+# Docs:  https://cert-manager.io/docs/trust/trust-manager/
+#
+# defaultPackage.enabled=true bakes the Mozilla CA list into the operator image so Bundles can use
+# `useDefaultCAs: true` (see bundle-wsh-internal-ca.yaml). The trust namespace defaults to the
+# release namespace (cert-manager); our CA Secret (internal-ca) already lives there.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: trust-manager
+  namespace: cert-manager
+spec:
+  interval: 30m
+  timeout: 10m
+  targetNamespace: cert-manager
+  install:
+    createNamespace: false
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: trust-manager
+      version: "v0.22.1"
+      sourceRef:
+        kind: HelmRepository
+        name: jetstack
+        namespace: cert-manager
+  values:
+    app:
+      trust:
+        # Namespace whose Secrets can be referenced as Bundle sources. Defaults to the release
+        # namespace; kept explicit so rotating the value is a single-line PR.
+        namespace: cert-manager
+    defaultPackage:
+      enabled: true
+    # Match wsh-require-resource-limits / wsh-require-run-as-non-root Kyverno policies.
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
+    secretTargets:
+      enabled: false
+    commonLabels:
+      app.kubernetes.io/part-of: cert-manager-production

--- a/clusters/production/apps/cert-manager/kustomization.yaml
+++ b/clusters/production/apps/cert-manager/kustomization.yaml
@@ -2,3 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - clusterissuer-letsencrypt-dns.yaml
+- clusterissuer-selfsigned-bootstrap.yaml
+- certificate-internal-ca.yaml
+- clusterissuer-internal-ca.yaml
+- bundle-wsh-internal-ca.yaml

--- a/clusters/production/apps/rabbitmq-production/certificate-rabbitmq-tls.yaml
+++ b/clusters/production/apps/rabbitmq-production/certificate-rabbitmq-tls.yaml
@@ -1,5 +1,18 @@
-# Let’s Encrypt TLS for RabbitMQ listeners (AMQPS / management HTTPS) once ClusterIssuer letsencrypt-dns is Ready.
-# SANs are public wsh.no names; see rabbitmq-secrets.md for hostname verification vs in-cluster DNS.
+# TLS for RabbitMQ AMQPS (5671) / management HTTPS (15671) listeners.
+#
+# Issued by the internal CA (clusters/production/apps/cert-manager/clusterissuer-internal-ca.yaml)
+# because Let's Encrypt cannot sign *.svc / *.svc.cluster.local names, and the Messaging Topology
+# Operator connects to https://rabbitmq.rabbitmq-production.svc:15671/ — hostname verification there
+# is what actually drives User/Permission/Vhost reconciliation.
+#
+# rabbitmq-cluster.yaml wires spec.tls.caSecretName to this same Secret so the topology operator
+# loads ca.crt from it as its HTTP client trust anchor (cert-manager writes ca.crt into CA-issued
+# TLS Secrets automatically).
+#
+# Trade-off: public *direct* TLS to the broker on rabbitmq.wsh.no:5671 / rabbitmq.mgmt.wsh.no:15671
+# now presents the internal CA — clients that verify TLS there must trust it. The public management
+# Ingress (rabbitmq-management-ingress.yaml) terminates LE TLS at Traefik and talks HTTP to the
+# backend on 15672, so https://rabbitmq.mgmt.wsh.no is unaffected. See rabbitmq-secrets.md §5.
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -12,7 +25,9 @@ spec:
   secretName: rabbitmq-tls
   issuerRef:
     kind: ClusterIssuer
-    name: letsencrypt-dns
+    name: internal-ca
   dnsNames:
+  - rabbitmq.rabbitmq-production.svc
+  - rabbitmq.rabbitmq-production.svc.cluster.local
   - rabbitmq.wsh.no
   - rabbitmq.mgmt.wsh.no

--- a/clusters/production/apps/rabbitmq-production/rabbitmq-cluster.yaml
+++ b/clusters/production/apps/rabbitmq-production/rabbitmq-cluster.yaml
@@ -74,6 +74,11 @@ spec:
                   type: RuntimeDefault
   tls:
     secretName: rabbitmq-tls
+    # Same Secret carries ca.crt (internal CA, see ../cert-manager/clusterissuer-internal-ca.yaml).
+    # The messaging topology operator loads ca.crt from this Secret to trust the broker's management
+    # HTTPS listener at https://rabbitmq.rabbitmq-production.svc:15671/ when reconciling User /
+    # Permission / Vhost CRs; without it, TLS hostname verification fails and topology never syncs.
+    caSecretName: rabbitmq-tls
   rabbitmq:
     additionalPlugins:
     - rabbitmq_auth_backend_oauth2

--- a/clusters/production/apps/rabbitmq-production/rabbitmq-secrets.md
+++ b/clusters/production/apps/rabbitmq-production/rabbitmq-secrets.md
@@ -92,13 +92,52 @@ Management plugin listens on **15672** (HTTP) inside the cluster. Traefik + Home
 
 ## 5. TLS (AMQPS / management)
 
-The cluster references **`spec.tls.secretName: rabbitmq-tls`**, populated by cert-manager **`Certificate`** [`certificate-rabbitmq-tls.yaml`](certificate-rabbitmq-tls.yaml) using **`ClusterIssuer`** `letsencrypt-dns` (RFC2136). Create the TSIG secret and fix the issuer nameserver/key name first — see [`../cert-manager/cert-manager-secrets.md`](../cert-manager/cert-manager-secrets.md).
+The cluster references **`spec.tls.secretName: rabbitmq-tls`** and **`spec.tls.caSecretName: rabbitmq-tls`**, populated by cert-manager **`Certificate`** [`certificate-rabbitmq-tls.yaml`](certificate-rabbitmq-tls.yaml) using **`ClusterIssuer`** **`internal-ca`** (self-signed, see [`../cert-manager/clusterissuer-internal-ca.yaml`](../cert-manager/clusterissuer-internal-ca.yaml) and [`../cert-manager/certificate-internal-ca.yaml`](../cert-manager/certificate-internal-ca.yaml)). The TSIG / Let's Encrypt flow is **not** used for this cert because LE cannot sign `*.svc` / `*.svc.cluster.local`, and the Messaging Topology Operator **must** reach `https://rabbitmq.rabbitmq-production.svc:15671/` to reconcile `User` / `Permission` / `Vhost` CRs — hostname verification there is what drives the whole topology sync.
 
-- **AMQPS** listens on **5671** when TLS is enabled (plain AMQP remains on **5672** unless you change listener config separately).
-- The issued certificate covers **`rabbitmq.wsh.no`** and **`rabbitmq.mgmt.wsh.no`**. Clients that verify TLS must use a **hostname present in the cert** (for example **`rabbitmq.wsh.no` as the server name**), not only `rabbitmq.rabbitmq-production.svc.cluster.local`, or hostname verification will fail against Let's Encrypt.
-- After Flux applies changes, confirm the cert is **Ready**, then run the checks in cert-manager-secrets.md §5 (OpenSSL).
+- **Certificate SANs:** `rabbitmq.rabbitmq-production.svc`, `rabbitmq.rabbitmq-production.svc.cluster.local`, `rabbitmq.wsh.no`, `rabbitmq.mgmt.wsh.no`.
+- **Topology operator trust:** `spec.tls.caSecretName: rabbitmq-tls` tells the operator to load `ca.crt` from the same Secret (cert-manager writes `ca.crt` into CA-issued TLS Secrets automatically) and use it as the HTTP client's root CA. Without `caSecretName`, reconciliation fails with `x509: certificate signed by unknown authority` or `certificate is valid for ..., not rabbitmq.rabbitmq-production.svc`.
+- **AMQPS** listens on **5671** when TLS is enabled (plain AMQP remains on **5672**).
+- **Public ingress** (`https://rabbitmq.mgmt.wsh.no`) is unaffected: Traefik `web` entrypoint → Service **`rabbitmq`** port **15672** (plain HTTP inside the cluster), and Traefik serves its own Let's Encrypt cert at the edge.
+- **Direct TLS to the broker from outside the cluster** (`rabbitmq.wsh.no:5671`, `rabbitmq.mgmt.wsh.no:15671`) now presents the internal CA. Clients that verify TLS there must trust `ca.crt` from Secret `rabbitmq-tls` (or set the AMQP client to skip verification — acceptable for local dev / debugging only). Grab the CA with:
 
-Public **Ingress** for the management UI is **`https://rabbitmq.mgmt.wsh.no`** (Traefik `web` entrypoint → Service **`rabbitmq`** port **15672**). Direct TLS to the broker on **`rabbitmq.mgmt.wsh.no`** (port **15671**) is separate and uses the **`rabbitmq-tls`** Secret on the nodes.
+  ```bash
+  kubectl get secret rabbitmq-tls -n rabbitmq-production -o jsonpath='{.data.ca\.crt}' | base64 -d > wsh-internal-ca.pem
+  ```
+
+- After Flux applies changes, confirm the cert is **Ready** (`kubectl get certificate -n rabbitmq-production`) and then that `User`, `Permission`, `Vhost` CRs flip to **`Ready=True`** (`kubectl get users.rabbitmq.com,permissions.rabbitmq.com,vhosts.rabbitmq.com -A`). If they were already stuck in `Ready=False` before the cert was fixed, force a reconcile:
+
+  ```bash
+  kubectl label user.rabbitmq.com       test-api         -n rabbitmq-production rotate=$(date +%s) --overwrite
+  kubectl label permission.rabbitmq.com test-api-test    -n rabbitmq-production rotate=$(date +%s) --overwrite
+  kubectl label vhost.rabbitmq.com      test             -n rabbitmq-production rotate=$(date +%s) --overwrite
+  ```
+
+- If you rotate the cert (e.g. expand SANs), the broker pods **do not auto-restart** on Secret change; roll the StatefulSet: `kubectl rollout restart statefulset/rabbitmq-server -n rabbitmq-production`.
+
+### In-cluster clients that need to trust the broker cert
+
+For **pods** that want to connect over AMQPS (`5671`) or HTTPS (`15671`) and verify the cert, the CA is distributed via **trust-manager** (see [`../cert-manager/bundle-wsh-internal-ca.yaml`](../cert-manager/bundle-wsh-internal-ca.yaml) and [`../cert-manager/install/trust-manager-helmrelease.yaml`](../cert-manager/install/trust-manager-helmrelease.yaml)). Any Namespace labelled **`wsh.no/trust-bundle: "true"`** gets a ConfigMap **`wsh-internal-ca`** with key **`ca-bundle.crt`** (Mozilla roots + our internal CA). Mount and point OpenSSL-based clients (including .NET 8+ `SslStream` / `RabbitMQ.Client` AMQPS) at it:
+
+```yaml
+env:
+  - name: SSL_CERT_FILE
+    value: /etc/ssl/wsh/ca-bundle.crt
+  - name: SSL_CERT_DIR
+    value: /etc/ssl/wsh
+volumeMounts:
+  - name: wsh-ca-bundle
+    mountPath: /etc/ssl/wsh
+    readOnly: true
+volumes:
+  - name: wsh-ca-bundle
+    configMap:
+      name: wsh-internal-ca
+      items:
+        - key: ca-bundle.crt
+          path: ca-bundle.crt
+```
+
+Reference implementation: [`../test-test/test-api-deployment.yaml`](../test-test/test-api-deployment.yaml). If .NET's chain-build ignores `SSL_CERT_FILE` on your base image, fall back to a RabbitMQ.Client `CertificateValidationCallback` that loads the PEM with `X509Certificate2.CreateFromPem(...)` and uses `X509ChainTrustMode.CustomRootTrust`.
 
 ## 6. Prometheus metrics and MQTT
 

--- a/clusters/production/apps/test-test/namespace.yaml
+++ b/clusters/production/apps/test-test/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   name: test-test
   labels:
     app.kubernetes.io/part-of: test-test
+    # trust-manager Bundle (../cert-manager/bundle-wsh-internal-ca.yaml) renders ConfigMap
+    # wsh-internal-ca in every namespace with this label — consumed by test-api-deployment.yaml.
+    wsh.no/trust-bundle: "true"

--- a/clusters/production/apps/test-test/test-api-deployment.yaml
+++ b/clusters/production/apps/test-test/test-api-deployment.yaml
@@ -69,6 +69,14 @@ spec:
             secretKeyRef:
               name: test-api-rabbitmq
               key: password
+        # Point OpenSSL (and by extension .NET 8+ SslStream / RabbitMQ.Client AMQPS) at the wsh-internal-ca
+        # bundle so the broker's self-signed management/AMQPS cert verifies. ConfigMap wsh-internal-ca is
+        # rendered into this namespace by trust-manager Bundle wsh-internal-ca (see
+        # ../cert-manager/bundle-wsh-internal-ca.yaml + the wsh.no/trust-bundle label on namespace.yaml).
+        - name: SSL_CERT_FILE
+          value: /etc/ssl/wsh/ca-bundle.crt
+        - name: SSL_CERT_DIR
+          value: /etc/ssl/wsh
         ports:
         - name: http
           containerPort: 8080
@@ -78,6 +86,17 @@ spec:
             port: http
           initialDelaySeconds: 3
           periodSeconds: 10
+        volumeMounts:
+        - name: wsh-ca-bundle
+          mountPath: /etc/ssl/wsh
+          readOnly: true
+      volumes:
+      - name: wsh-ca-bundle
+        configMap:
+          name: wsh-internal-ca
+          items:
+          - key: ca-bundle.crt
+            path: ca-bundle.crt
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
…bbitMQ

- Added new resources for managing an internal CA, including `certificate-internal-ca.yaml`, `clusterissuer-internal-ca.yaml`, and `clusterissuer-selfsigned-bootstrap.yaml`.
- Implemented a trust-manager Bundle (`bundle-wsh-internal-ca.yaml`) to distribute the internal CA across namespaces, enabling secure communication for workloads.
- Updated RabbitMQ configurations to utilize the internal CA for TLS, ensuring proper certificate validation for in-cluster DNS names.
- Enhanced documentation in `rabbitmq-secrets.md` to clarify the use of the internal CA and trust management setup.
- Modified `kustomization.yaml` files to include new resources for deployment.

## Description 💬

<!--- Describe your changes in detail -->
