### PR TITLE
feat: Add Cilium LoadBalancer IPAM and L2 announcement for Mosquitto …

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,6 +79,7 @@ updates:
   - "/clusters/production/apps/ceph-csi"
   - "/clusters/production/apps/cert-manager"
   - "/clusters/production/apps/cert-manager/install"
+  - "/clusters/production/apps/cilium-lb"
   - "/clusters/production/apps/cnpg-system"
   - "/clusters/production/apps/clutterstock"
   - "/clusters/production/apps/clutterstock-migrate"
@@ -100,6 +101,7 @@ updates:
   - "/clusters/production/apps/wshno"
   - "/clusters/production/apps/home-assistant-production"
   - "/clusters/production/apps/node-red-production"
+  - "/clusters/production/apps/mosquitto-production"
   - "/clusters/production/apps/shared/production"
   - "/clusters/production/flux-system"
   schedule:

--- a/clusters/production/apps/cilium-lb/ciliuml2announcementpolicy.yaml
+++ b/clusters/production/apps/cilium-lb/ciliuml2announcementpolicy.yaml
@@ -1,0 +1,18 @@
+# ARP-announce LoadBalancer VIPs on the node primary NIC (eth0, 10.20.13.0/24).
+# One node is elected per service via a k8s Lease, with automatic failover.
+# Requires l2announcements.enabled in the Cilium Helm stanza (k0s) — see
+# namespace-note.md. v2alpha1: CiliumL2AnnouncementPolicy is not yet graduated
+# to v2 in Cilium v1.19.
+apiVersion: cilium.io/v2alpha1
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: lan-l2
+spec:
+  loadBalancerIPs: true
+  externalIPs: false
+  interfaces:
+  - ^eth0$
+  nodeSelector:
+    matchExpressions:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists

--- a/clusters/production/apps/cilium-lb/ciliumloadbalancerippool.yaml
+++ b/clusters/production/apps/cilium-lb/ciliumloadbalancerippool.yaml
@@ -1,0 +1,11 @@
+# Assignable LoadBalancer VIP range. Single address for now (MQTT broker).
+# Must be in the node L2 (10.20.13.0/24) for L2 announcement ARP to work,
+# and outside the DHCP range / otherwise unused.
+apiVersion: cilium.io/v2
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: lan-pool
+spec:
+  blocks:
+  - start: "10.20.13.100"
+    stop: "10.20.13.100"

--- a/clusters/production/apps/cilium-lb/kustomization.yaml
+++ b/clusters/production/apps/cilium-lb/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ciliumloadbalancerippool.yaml
+- ciliuml2announcementpolicy.yaml

--- a/clusters/production/apps/cilium-lb/namespace-note.md
+++ b/clusters/production/apps/cilium-lb/namespace-note.md
@@ -1,0 +1,41 @@
+# Cilium LB-IPAM + L2 announcements
+
+Cluster-scoped Cilium CRs that turn `Service type: LoadBalancer` into a real,
+ARP-reachable VIP on the node L2 (`10.20.13.0/24`) — no MetalLB.
+
+- **`ciliumloadbalancerippool.yaml`** — the assignable VIP range. Currently a
+  single address reserved for the MQTT broker.
+- **`ciliuml2announcementpolicy.yaml`** — makes Cilium ARP-announce LB VIPs on
+  `eth0`. One node is elected per service (k8s Lease) with automatic failover.
+
+## Prerequisite (NOT GitOps)
+
+L2 announcements must be enabled in the **Cilium Helm stanza in k0s** — it is
+**not** a manifest in this repo. Required keys in `/etc/k0s/k0s.yaml` on every
+controller (then a gated rolling reconcile, see `infra/k0s/cilium-k0s-setup.md`):
+
+```yaml
+          l2announcements:
+            enabled: true
+          k8sClientRateLimit:
+            qps: 10
+            burst: 20
+```
+
+Verify after reconcile:
+
+```bash
+kubectl -n kube-system get cm cilium-config -o jsonpath='{.data.enable-l2-announcements}'
+# -> true
+```
+
+LB-IPAM itself is already enabled in this Cilium build (`enable-lb-ipam=true`),
+so the pool below assigns immediately; without the L2 prerequisite the VIP is
+assigned but unreachable.
+
+## VIP
+
+`10.20.13.100` — reserved here for `mosquitto-production/mosquitto`. Must stay
+outside the DHCP range and unused elsewhere. IoT/ESP clients on other VLANs
+reach it via normal L3 routing (router/firewall must permit
+`<iot-subnet> -> 10.20.13.100:1883`).

--- a/clusters/production/apps/kustomization.yaml
+++ b/clusters/production/apps/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
 # platform-production also hosts the cluster-wide pbs-encryption-keyfile clone policy + RBAC.
 - platform-production
 - ceph-csi
+# Cilium LB-IPAM pool + L2 announcement policy (VIP for type=LoadBalancer svcs).
+- cilium-lb
 # Pointer to a second (private) Flux Git source. See private-apps/.
 - private-apps
 # cnpg-system + postgres-* Cluster CRs: separate Flux Kustomizations (gotk-sync) so Helm installs CRDs before dry-run.
@@ -24,6 +26,7 @@ resources:
 - clutterstock-test
 - clutterstock
 - home-assistant-production
+- mosquitto-production
 - node-red-production
 - wshno
 - ingress.yaml

--- a/clusters/production/apps/mosquitto-production/cilium-mqtt-ingress.yaml
+++ b/clusters/production/apps/mosquitto-production/cilium-mqtt-ingress.yaml
@@ -1,0 +1,37 @@
+# Ingress to the broker on 1883 from:
+#  - the Home Assistant pod (in-cluster, pod-to-pod via ClusterIP)
+#  - LAN / IoT devices reaching the LoadBalancer VIP (arrive as world; the
+#    LB datapath is forwarded by host/remote-node). Scoped to the 10.20.0.0/16
+#    homelab range so the broker isn't open to arbitrary world identities.
+# Auth (password_file) is the real gate; this just narrows the network surface.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-mqtt-to-mosquitto
+  namespace: mosquitto-production
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: mosquitto
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: home-assistant-production
+        app: home-assistant
+    toPorts:
+    - ports:
+      - port: "1883"
+        protocol: TCP
+  - fromEntities:
+    - host
+    - remote-node
+    toPorts:
+    - ports:
+      - port: "1883"
+        protocol: TCP
+  - fromCIDR:
+    - 10.20.0.0/16
+    toPorts:
+    - ports:
+      - port: "1883"
+        protocol: TCP

--- a/clusters/production/apps/mosquitto-production/kustomization.yaml
+++ b/clusters/production/apps/mosquitto-production/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- mosquitto-configmap.yaml
+- mosquitto-statefulset.yaml
+- cilium-mqtt-ingress.yaml
+- kyverno-rbac-generate-pbs-encryption-keyfile.yaml
+- mosquitto-pbs-backup-cronjob.yaml

--- a/clusters/production/apps/mosquitto-production/kyverno-rbac-generate-pbs-encryption-keyfile.yaml
+++ b/clusters/production/apps/mosquitto-production/kyverno-rbac-generate-pbs-encryption-keyfile.yaml
@@ -1,0 +1,31 @@
+# Kyverno's validate-policy admission webhook checks SAR on the generate target
+# namespace; the background controller applies the clone/sync of
+# pbs-encryption-keyfile (see platform-production clone-pbs-encryption-keyfile).
+# Rules cover all secrets in this namespace despite the secret-specific role name —
+# same pattern as home-assistant-production's equivalent.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kyverno-generate-secret-pbs-encryption-keyfile
+  namespace: mosquitto-production
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kyverno-generate-secret-pbs-encryption-keyfile
+  namespace: mosquitto-production
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kyverno-generate-secret-pbs-encryption-keyfile
+subjects:
+- kind: ServiceAccount
+  name: kyverno-admission-controller
+  namespace: kyverno
+- kind: ServiceAccount
+  name: kyverno-background-controller
+  namespace: kyverno

--- a/clusters/production/apps/mosquitto-production/mosquitto-configmap.yaml
+++ b/clusters/production/apps/mosquitto-production/mosquitto-configmap.yaml
@@ -1,0 +1,29 @@
+# Single broker, single retained store (the whole reason we use a dedicated
+# Mosquitto instead of RabbitMQ MQTT — deterministic HA discovery).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mosquitto-config
+  namespace: mosquitto-production
+data:
+  mosquitto.conf: |
+    # Plain MQTT. In-cluster (HA) reaches this via the ClusterIP DNS name;
+    # external ESP/IoT clients via the LoadBalancer VIP 10.20.13.100.
+    listener 1883 0.0.0.0
+    protocol mqtt
+
+    # Authenticated only — the listener is reachable from the LAN via the VIP.
+    allow_anonymous false
+    password_file /mosquitto/auth/passwd
+
+    # Retained messages + subscription state survive restarts (HA discovery).
+    persistence true
+    persistence_location /mosquitto/data/
+    autosave_interval 30
+
+    log_dest stdout
+    log_type error
+    log_type warning
+    log_type notice
+    connection_messages true
+    max_queued_messages 1000

--- a/clusters/production/apps/mosquitto-production/mosquitto-pbs-backup-cronjob.yaml
+++ b/clusters/production/apps/mosquitto-production/mosquitto-pbs-backup-cronjob.yaml
@@ -1,0 +1,109 @@
+# Daily backup of Mosquitto's /mosquitto/data PVC (retained messages +
+# persistence DB) to Proxmox Backup Server. Same PBS client image/tag as the
+# home-assistant / node-red backups.
+#
+# Filesystem variant: the ceph-rbd PVC is ReadWriteOnce, so this Job can only
+# mount it on the node where the StatefulSet pod already has it attached.
+# requiredDuringScheduling podAffinity pins the backup pod to the Mosquitto
+# pod's node (RWO permits multiple pods sharing the volume on the SAME node);
+# the mount is readOnly so the backup never writes the live volume. Runs as
+# root so file ownership (uid 1883) never blocks the read. No restricted-PSS
+# policy on this cluster forbids it.
+#
+# NOTE: hot copy of mosquitto.db — usually restorable; acceptable for a homelab
+# daily. Retained MQTT discovery re-publishes anyway on device activity.
+#
+# Prerequisites:
+#   1. Create Secret `mosquitto-pbs-backup` (see mosquitto-pbs-backup-secrets.md).
+#   2. Source Secret pbs-encryption-keyfile present in platform-production (cloned
+#      here by the clone-pbs-encryption-keyfile ClusterPolicy + this ns's Kyverno
+#      RBAC). See the two-push ordering note in mosquitto-pbs-backup-secrets.md.
+#
+# Trigger an immediate run (outside the schedule):
+#   kubectl -n mosquitto-production create job --from=cronjob/mosquitto-pbs-backup mosquitto-pbs-backup-manual-$(date +%s)
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mosquitto-pbs-backup
+  namespace: mosquitto-production
+spec:
+  # 04:30 Europe/Oslo daily — clear of the 02:30-03:30 postgres/authelia window,
+  # the 04:00 home-assistant and 04:15 node-red backups.
+  schedule: "30 4 * * *"
+  timeZone: Europe/Oslo
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 3600
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: mosquitto-pbs-backup
+            app.kubernetes.io/component: mosquitto-pbs-backup
+        spec:
+          nodeSelector:
+            kubernetes.io/arch: amd64
+          # Co-locate with the running Mosquitto pod so the RWO ceph-rbd volume is mountable.
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    app: mosquitto
+                topologyKey: kubernetes.io/hostname
+          hostname: mosquitto
+          restartPolicy: Never
+          containers:
+          - name: backup
+            image: ghcr.io/hwinther/proxmox/proxmox/pbs/backup-client:0.6.1
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              set -- backup
+              [ -n "${PBS_NAMESPACE:-}" ] && set -- "$@" --ns "$PBS_NAMESPACE"
+              [ -f /etc/pbs/keyfile ] && set -- "$@" --keyfile /etc/pbs/keyfile
+              set -- "$@" data.pxar:/data
+              exec /usr/bin/proxmox-backup-client "$@"
+            envFrom:
+            - secretRef:
+                name: mosquitto-pbs-backup
+            securityContext:
+              runAsUser: 0
+              runAsGroup: 0
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                cpu: "1"
+                memory: 256Mi
+            volumeMounts:
+            - name: mq-data
+              mountPath: /data
+              readOnly: true
+            - name: pbs-keyfile
+              mountPath: /etc/pbs
+              readOnly: true
+          volumes:
+          - name: mq-data
+            persistentVolumeClaim:
+              claimName: data-mosquitto-0
+              readOnly: true
+          - name: pbs-keyfile
+            secret:
+              secretName: pbs-encryption-keyfile
+              optional: true
+              items:
+              - key: keyfile
+                path: keyfile
+                mode: 0400

--- a/clusters/production/apps/mosquitto-production/mosquitto-pbs-backup-secrets.md
+++ b/clusters/production/apps/mosquitto-production/mosquitto-pbs-backup-secrets.md
@@ -1,0 +1,72 @@
+# Proxmox Backup Server credentials (`mosquitto-production`)
+
+The backup CronJob loads env vars from the Kubernetes Secret
+**`mosquitto-pbs-backup`** in namespace **`mosquitto-production`**. Create it
+with `kubectl`. Do not commit real values to git.
+
+The cluster-wide PBS encryption keyfile lives in `platform-production` and is
+cloned here automatically — see
+[`../platform-production/pbs-encryption-keyfile.md`](../platform-production/pbs-encryption-keyfile.md).
+The clone needs this namespace's Kyverno RBAC
+(`kyverno-rbac-generate-pbs-encryption-keyfile.yaml`) **and** a clone rule in
+`../platform-production/kyverno-clusterpolicy-clone-pbs-encryption-keyfile.yaml`.
+
+## ⚠️ Two-push ordering (hard requirement)
+
+The clone ClusterPolicy's validate-policy webhook **denies the whole policy** if
+a target namespace's Kyverno RBAC isn't already live. So land this in **two
+separate commits/pushes**:
+
+1. **Push 1:** this app dir incl. `kyverno-rbac-generate-pbs-encryption-keyfile.yaml`
+   + the CronJob. Let Flux reconcile so the RBAC RoleBinding is live.
+2. **Push 2:** the new `clone-to-mosquitto-production` rule appended to the
+   platform-production ClusterPolicy.
+
+Adding both in one commit dry-run-fails the ClusterPolicy and blocks the Flux
+Kustomization. Until the keyfile is cloned the CronJob still runs (mount is
+`optional: true`) but **unencrypted**.
+
+## Required keys
+
+| Key              | Purpose                                                              |
+| ---------------- | -------------------------------------------------------------------- |
+| `PBS_REPOSITORY` | Repository string for `proxmox-backup-client`.                       |
+| `PBS_PASSWORD`   | Password or API token secret value.                                  |
+
+## Optional keys
+
+| Key                       | When to set                                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------ |
+| `PBS_FINGERPRINT`         | Self-signed PBS or pinned cert fingerprint.                                                 |
+| `PBS_NAMESPACE`           | PBS datastore namespace (e.g. `Production/mosquitto`). Job appends `--ns`. Create it in the PBS UI first. |
+| `PBS_ENCRYPTION_PASSWORD` | **Always set** — the cluster `pbs-encryption-keyfile` is passphrase-protected (project convention). |
+| `PBS_RESTORE_SNAPSHOT`    | Only for a manual restore: full snapshot path.                                             |
+
+## Create the Secret
+
+```bash
+kubectl -n mosquitto-production create secret generic mosquitto-pbs-backup \
+  --from-literal=PBS_REPOSITORY='user@pbs!tokenid@pbs.example.com:8007:datastore' \
+  --from-literal=PBS_PASSWORD='your-api-token-uuid-here' \
+  --from-literal=PBS_NAMESPACE='Production/mosquitto' \
+  --from-literal=PBS_ENCRYPTION_PASSWORD='<pbs-encryption-keyfile passphrase>'
+```
+
+## Trigger an out-of-schedule backup
+
+```bash
+kubectl -n mosquitto-production create job \
+  --from=cronjob/mosquitto-pbs-backup mosquitto-pbs-backup-manual-$(date +%s)
+```
+
+## Restore (manual, destructive — outline)
+
+```bash
+kubectl -n mosquitto-production patch secret mosquitto-pbs-backup --type merge \
+  -p '{"stringData":{"PBS_RESTORE_SNAPSHOT":"host/mosquitto/<ts>"}}'
+kubectl -n mosquitto-production scale statefulset mosquitto --replicas=0
+kubectl -n mosquitto-production wait --for=delete pod -l app=mosquitto --timeout=120s
+# restore data.pxar into the PVC via a one-off proxmox-backup-client restore Job
+# (mirror home-assistant-pbs-restore-job.yaml), then:
+kubectl -n mosquitto-production scale statefulset mosquitto --replicas=1
+```

--- a/clusters/production/apps/mosquitto-production/mosquitto-secrets.md
+++ b/clusters/production/apps/mosquitto-production/mosquitto-secrets.md
@@ -1,0 +1,52 @@
+# Mosquitto credentials
+
+The broker runs `allow_anonymous false` + `password_file`. The password file is
+**not** in this repo — it lives only in the `mosquitto-auth` Secret in
+`mosquitto-production`, mounted read-only at `/mosquitto/auth/passwd`.
+
+The file is a standard `mosquitto_passwd` file (`username:<bcrypt-hash>` lines).
+Generate it with the mosquitto CLI image so the hash format matches the broker:
+
+```bash
+# Pick credentials. Use one shared device user, or one per consumer.
+HA_USER=homeassistant
+HA_PW="$(openssl rand -base64 24 | tr -d '\n')"
+ESP_USER=esp
+ESP_PW="$(openssl rand -base64 24 | tr -d '\n')"
+
+# Build the passwd file with the same image the broker uses.
+docker run --rm --entrypoint sh eclipse-mosquitto:2.0.20 -c '
+  touch /tmp/passwd
+  mosquitto_passwd -b /tmp/passwd '"$HA_USER"' '"$HA_PW"'
+  mosquitto_passwd -b /tmp/passwd '"$ESP_USER"' '"$ESP_PW"'
+  cat /tmp/passwd' > passwd
+
+kubectl create secret generic mosquitto-auth \
+  --namespace mosquitto-production \
+  --from-file=passwd=./passwd
+
+rm -f passwd
+```
+
+Record `HA_USER`/`HA_PW` — they go into Home Assistant's MQTT config entry
+(broker `mosquitto.mosquitto-production.svc.cluster.local`, port `1883`).
+`ESP_USER`/`ESP_PW` go into ESP/Tasmota/ESPHome firmware (broker
+`10.20.13.100`, port `1883`).
+
+To add/rotate a user later: regenerate the file the same way and
+`kubectl create secret ... --dry-run=client -o yaml | kubectl apply -f -`, then
+restart the pod (`kubectl -n mosquitto-production rollout restart statefulset/mosquitto`)
+so it re-reads the file.
+
+## Connectivity recap
+
+- **In-cluster (HA):** `mosquitto.mosquitto-production.svc.cluster.local:1883`
+  (CiliumNetworkPolicy allows the `home-assistant` pod).
+- **External (ESP/IoT):** `10.20.13.100:1883` — Cilium LB-IPAM VIP, L2-announced
+  on `10.20.13.0/24`. Devices on other VLANs need a router/firewall rule
+  permitting `<iot-subnet> -> 10.20.13.100:1883`.
+- **Prerequisite:** L2 announcements enabled in the k0s Cilium stanza (see
+  `clusters/production/apps/cilium-lb/namespace-note.md`).
+- **TLS (8883):** not configured yet. Plain 1883 only. Adding a TLS listener
+  needs a cert decision (ESP firmware won't trust the internal cert-manager CA
+  without baking it in) — tracked as a follow-up.

--- a/clusters/production/apps/mosquitto-production/mosquitto-statefulset.yaml
+++ b/clusters/production/apps/mosquitto-production/mosquitto-statefulset.yaml
@@ -1,0 +1,134 @@
+# Mosquitto MQTT broker for Home Assistant + DIY ESP/IoT devices.
+# Single replica: one authoritative retained-message store. State (retained
+# msgs + persistence DB) lives on a ceph-rbd PVC. eclipse-mosquitto runs as
+# the image's built-in non-root uid/gid 1883.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mosquitto
+  namespace: mosquitto-production
+spec:
+  serviceName: mosquitto-headless
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mosquitto
+  template:
+    metadata:
+      labels:
+        app: mosquitto
+        app.kubernetes.io/name: mosquitto
+        app.kubernetes.io/component: messaging
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1883
+        runAsGroup: 1883
+        fsGroup: 1883
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: mosquitto
+        image: docker.io/library/eclipse-mosquitto:2.0.20
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        ports:
+        - name: mqtt
+          containerPort: 1883
+          protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: mqtt
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: mqtt
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          failureThreshold: 6
+        resources:
+          requests:
+            cpu: 25m
+            memory: 32Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+        volumeMounts:
+        - name: config
+          mountPath: /mosquitto/config/mosquitto.conf
+          subPath: mosquitto.conf
+          readOnly: true
+        - name: auth
+          mountPath: /mosquitto/auth
+          readOnly: true
+        - name: data
+          mountPath: /mosquitto/data
+      volumes:
+      - name: config
+        configMap:
+          name: mosquitto-config
+      - name: auth
+        secret:
+          secretName: mosquitto-auth
+          items:
+          - key: passwd
+            path: passwd
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+      labels:
+        app: mosquitto
+        app.kubernetes.io/name: mosquitto
+        app.kubernetes.io/component: messaging
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: ceph-rbd
+      resources:
+        requests:
+          storage: 1Gi
+---
+# Headless governing Service for the StatefulSet (stable identity only).
+apiVersion: v1
+kind: Service
+metadata:
+  name: mosquitto-headless
+  namespace: mosquitto-production
+spec:
+  clusterIP: None
+  selector:
+    app: mosquitto
+  ports:
+  - name: mqtt
+    port: 1883
+    targetPort: mqtt
+    protocol: TCP
+---
+# LoadBalancer Service: stable LAN VIP via Cilium LB-IPAM + L2 announce.
+# In-cluster clients (HA) use mosquitto.mosquitto-production.svc.cluster.local:1883;
+# external ESP/IoT clients use 10.20.13.100:1883.
+apiVersion: v1
+kind: Service
+metadata:
+  name: mosquitto
+  namespace: mosquitto-production
+  annotations:
+    lbipam.cilium.io/ips: "10.20.13.100"
+spec:
+  type: LoadBalancer
+  # Cluster (not Local): single-replica StatefulSet may not run on the
+  # L2-announcing node; Cluster lets any node forward. Client IP is SNATed,
+  # which is fine — access is gated by MQTT auth, not source IP.
+  externalTrafficPolicy: Cluster
+  selector:
+    app: mosquitto
+  ports:
+  - name: mqtt
+    port: 1883
+    targetPort: mqtt
+    protocol: TCP

--- a/clusters/production/apps/mosquitto-production/namespace.yaml
+++ b/clusters/production/apps/mosquitto-production/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mosquitto-production
+  labels:
+    app.kubernetes.io/part-of: production


### PR DESCRIPTION
…broker

- Introduced Cilium LoadBalancer IP pool and L2 announcement policy for managing LoadBalancer VIPs.
- Updated kustomization files to include new Cilium resources.
- Added Mosquitto broker configuration, StatefulSet, and ingress policies to support MQTT communication.
- Created documentation for Mosquitto credentials and connectivity setup.

## Description 💬

<!--- Describe your changes in detail -->
