### PR TITLE
feat(esp-poller): integrate esp-poller into production environment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -113,6 +113,9 @@ updates:
   - "/clusters/production/apps/node-red-production"
   - "/clusters/production/apps/mosquitto-production"
   - "/clusters/production/apps/esp-poller-production"
+  - "/clusters/production/apps/previews/clutterstock"
+  - "/clusters/production/apps/previews/clutterstock/base"
+  - "/clusters/production/apps/previews/clutterstock/databases"
   - "/clusters/production/apps/shared/production"
   - "/clusters/production/flux-system"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,16 @@ updates:
   cooldown:
     default-days: 7
 
+# esp-poller container image — pins its own runtime deps in requirements.txt
+# (kept separate from the root pyproject so the image rebuild surface is small).
+- package-ecosystem: "pip"
+  directory: "/images/esp-poller"
+  open-pull-requests-limit: 20
+  schedule:
+    interval: "weekly"
+  cooldown:
+    default-days: 7
+
 # edge-sdr cluster (k0s / SDR edge).
 - package-ecosystem: "docker"
   directories:
@@ -102,6 +112,7 @@ updates:
   - "/clusters/production/apps/home-assistant-production"
   - "/clusters/production/apps/node-red-production"
   - "/clusters/production/apps/mosquitto-production"
+  - "/clusters/production/apps/esp-poller-production"
   - "/clusters/production/apps/shared/production"
   - "/clusters/production/flux-system"
   schedule:

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,7 +7,4 @@
   <component name="PythonCompatibilityInspectionAdvertiser">
     <option name="version" value="3" />
   </component>
-  <component name="RuffConfiguration">
-    <option name="enabled" value="true" />
-  </component>
 </project>

--- a/.idea/pyLspTools.xml
+++ b/.idea/pyLspTools.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RuffConfiguration">
+    <option name="enabled" value="true" />
+  </component>
+</project>

--- a/clusters/production/apps/esp-poller-production/esp-poller-configmap.yaml
+++ b/clusters/production/apps/esp-poller-production/esp-poller-configmap.yaml
@@ -1,0 +1,65 @@
+# Device list — one entry per ESP. To add a device or endpoint: append here, push, Flux
+# reconciles, Deployment auto-rolls (annotation digest changes), HA Discovery + Prometheus
+# pick up new sensors.
+#
+# A device has one or more endpoints. By default an endpoint must return
+# {"<sensor_key>": <number>, ...}. If it packs multiple readings into one string field,
+# add a `parser` block whose regex named groups map to sensor keys.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: esp-poller-devices
+  namespace: esp-poller-production
+data:
+  devices.yaml: |
+    devices:
+      - id: sensor01
+        name: Sensor 01
+        model: esp-dht11
+        endpoints:
+          - id: dht11
+            # Response: {"value": "25c26"} → 25 °C, 26 %.
+            url: http://10.20.1.142:8080/api/sensor01/dht11/value
+            parser:
+              source: value
+              regex: '^(?P<temperature>\d+)c(?P<humidity>\d+)$'
+            sensors:
+              - {key: temperature, unit: "°C", device_class: temperature}
+              - {key: humidity,    unit: "%",  device_class: humidity}
+          - id: lightsensor
+            # Response: {"value": "0"} → raw ADC integer (~0 dark, ~900 bright).
+            # No device_class: this is uncalibrated, not lux.
+            url: http://10.20.1.142:8080/api/sensor01/lightsensor/read
+            parser:
+              source: value
+              regex: '^(?P<light>\d+)$'
+            sensors:
+              - {key: light, unit: "raw"}
+      - id: sensor02
+        name: Sensor 02
+        model: esp-dht11
+        endpoints:
+          - id: dht11
+            url: http://10.20.1.142:8080/api/sensor02/dht11/value
+            parser:
+              source: value
+              regex: '^(?P<temperature>\d+)c(?P<humidity>\d+)$'
+            sensors:
+              - {key: temperature, unit: "°C", device_class: temperature}
+              - {key: humidity,    unit: "%",  device_class: humidity}
+          - id: lightsensor
+            url: http://10.20.1.142:8080/api/sensor02/lightsensor/read
+            parser:
+              source: value
+              regex: '^(?P<light>\d+)$'
+            sensors:
+              - {key: light, unit: "raw"}
+          - id: dsb
+            # DS18B20 returns a decimal °C string, e.g. {"value": "26.9375"}.
+            # Distinct key (`dsb_temperature`) so it doesn't collide with the DHT11's `temperature`.
+            url: http://10.20.1.142:8080/api/sensor02/dsb/value
+            parser:
+              source: value
+              regex: '^(?P<dsb_temperature>\d+(?:\.\d+)?)$'
+            sensors:
+              - {key: dsb_temperature, unit: "°C", device_class: temperature}

--- a/clusters/production/apps/esp-poller-production/esp-poller-deployment.yaml
+++ b/clusters/production/apps/esp-poller-production/esp-poller-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         fsGroup: 1888
       containers:
       - name: esp-poller
-        image: ghcr.io/hwinther/proxmox/esp-poller:0.1.0
+        image: ghcr.io/hwinther/proxmox/esp-poller:0.6.1@sha256:9d0742e5901f0f691238d98543d72d0cc4b1f24fc82be6aa29b2607e93ddef4b
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/clusters/production/apps/esp-poller-production/esp-poller-deployment.yaml
+++ b/clusters/production/apps/esp-poller-production/esp-poller-deployment.yaml
@@ -1,0 +1,112 @@
+# Bump esp-poller image tag via Dependabot / manual edit; the workflow
+# .github/workflows/build-esp-poller.yml publishes images on manual dispatch.
+# Pre-rollout: create the esp-poller-mqtt Secret (see esp-poller-mqtt-secrets.md).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: esp-poller
+  namespace: esp-poller-production
+spec:
+  replicas: 1
+  # Recreate (not RollingUpdate): a second poller would double-publish to MQTT
+  # during the overlap and briefly skew Prometheus gauges.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: esp-poller
+  template:
+    metadata:
+      labels:
+        app: esp-poller
+        app.kubernetes.io/name: esp-poller
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1888
+        runAsGroup: 1888
+        fsGroup: 1888
+      containers:
+      - name: esp-poller
+        image: ghcr.io/hwinther/proxmox/esp-poller:0.1.0
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        env:
+        - name: POLL_INTERVAL_SEC
+          value: "30"
+        - name: HTTP_TIMEOUT_SEC
+          value: "5"
+        - name: METRICS_PORT
+          value: "9100"
+        - name: MQTT_HOST
+          value: mosquitto.mosquitto-production.svc.cluster.local
+        - name: MQTT_PORT
+          value: "1883"
+        - name: MQTT_USER
+          valueFrom:
+            secretKeyRef:
+              name: esp-poller-mqtt
+              key: username
+        - name: MQTT_PASS
+          valueFrom:
+            secretKeyRef:
+              name: esp-poller-mqtt
+              key: password
+        ports:
+        - name: metrics
+          containerPort: 9100
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 15
+          periodSeconds: 30
+          failureThreshold: 3
+        resources:
+          requests:
+            cpu: 20m
+            memory: 48Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+        volumeMounts:
+        - name: devices
+          mountPath: /etc/esp-poller
+          readOnly: true
+      volumes:
+      - name: devices
+        configMap:
+          name: esp-poller-devices
+---
+# Service exists so the kube-prometheus-stack ServiceMonitor can match by selector;
+# the port name `metrics` matches the additionalServiceMonitors entry in
+# ../observability/kube-prometheus-stack-helmrelease.yaml.
+apiVersion: v1
+kind: Service
+metadata:
+  name: esp-poller
+  namespace: esp-poller-production
+  labels:
+    app.kubernetes.io/name: esp-poller
+spec:
+  type: ClusterIP
+  selector:
+    app: esp-poller
+  ports:
+  - name: metrics
+    port: 9100
+    targetPort: metrics
+    protocol: TCP

--- a/clusters/production/apps/esp-poller-production/esp-poller-mqtt-secrets.md
+++ b/clusters/production/apps/esp-poller-production/esp-poller-mqtt-secrets.md
@@ -1,0 +1,25 @@
+# esp-poller MQTT credentials
+
+The poller authenticates to Mosquitto with a dedicated user (separate from the
+shared `esp` device user) so it can be rotated independently.
+
+The Secret is **not** in this repo. Create it once on the cluster:
+
+```bash
+POLLER_USER=esp-poller
+POLLER_PW="$(openssl rand -base64 24 | tr -d '\n')"
+
+# 1) Append the user to mosquitto-auth (see ../mosquitto-production/mosquitto-secrets.md
+#    for how to regenerate the passwd file with the existing users + this new one,
+#    then re-apply mosquitto-auth and restart the broker pod).
+
+# 2) Create the poller-side credential Secret.
+kubectl create secret generic esp-poller-mqtt \
+  --namespace esp-poller-production \
+  --from-literal=username="$POLLER_USER" \
+  --from-literal=password="$POLLER_PW"
+```
+
+The Deployment reads `MQTT_USER` and `MQTT_PASS` from this Secret. Rotate by
+re-creating the Secret (`kubectl create ... --dry-run=client -o yaml | kubectl apply -f -`)
+and `kubectl -n esp-poller-production rollout restart deployment/esp-poller`.

--- a/clusters/production/apps/esp-poller-production/kustomization.yaml
+++ b/clusters/production/apps/esp-poller-production/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- esp-poller-configmap.yaml
+- esp-poller-deployment.yaml
+- networkpolicies.yaml
+# ServiceMonitor for /metrics is declared inline in
+# ../observability/kube-prometheus-stack-helmrelease.yaml (additionalServiceMonitors)
+# to match how obs-otel-collector, RabbitMQ and CNPG scrapes are wired up there.

--- a/clusters/production/apps/esp-poller-production/namespace.yaml
+++ b/clusters/production/apps/esp-poller-production/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: esp-poller-production
+  labels:
+    app.kubernetes.io/part-of: esp-poller-production

--- a/clusters/production/apps/esp-poller-production/networkpolicies.yaml
+++ b/clusters/production/apps/esp-poller-production/networkpolicies.yaml
@@ -1,0 +1,61 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: esp-poller
+  namespace: esp-poller-production
+spec:
+  podSelector:
+    matchLabels:
+      app: esp-poller
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Prometheus scrape of /metrics on :9100.
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: observability-production
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    ports:
+    - port: 9100
+      protocol: TCP
+  egress:
+  # DNS.
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+  # Mosquitto in-cluster.
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: mosquitto-production
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: mosquitto
+    ports:
+    - port: 1883
+      protocol: TCP
+  # ESP devices on the LAN (HTTP). Narrow to the homelab range; metadata IP excluded
+  # to match the convention used elsewhere in this repo.
+  - to:
+    - ipBlock:
+        cidr: 10.20.0.0/16
+        except:
+        - 169.254.169.254/32
+    ports:
+    - port: 80
+      protocol: TCP
+    - port: 8080
+      protocol: TCP

--- a/clusters/production/apps/kustomization.yaml
+++ b/clusters/production/apps/kustomization.yaml
@@ -28,6 +28,7 @@ resources:
 - home-assistant-production
 - mosquitto-production
 - node-red-production
+- esp-poller-production
 - wshno
 - ingress.yaml
 - hubble-ui-ingress.yaml

--- a/clusters/production/apps/mosquitto-production/cilium-mqtt-ingress.yaml
+++ b/clusters/production/apps/mosquitto-production/cilium-mqtt-ingress.yaml
@@ -31,6 +31,15 @@ spec:
     - ports:
       - port: "1883"
         protocol: TCP
+  # esp-poller publishes ESP sensor readings + HA Discovery configs.
+  - fromEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: esp-poller-production
+        app: esp-poller
+    toPorts:
+    - ports:
+      - port: "1883"
+        protocol: TCP
   - fromEntities:
     - host
     - remote-node

--- a/clusters/production/apps/observability/kube-prometheus-stack-helmrelease.yaml
+++ b/clusters/production/apps/observability/kube-prometheus-stack-helmrelease.yaml
@@ -122,6 +122,19 @@ spec:
         - port: metrics
           interval: 15s
           scrapeTimeout: 10s
+      # DIY ESP devices: esp-poller exports each numeric sensor reading as a
+      # gauge labeled by device (metric name `esp_<sensor_key>`).
+      - name: esp-poller
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: esp-poller
+        namespaceSelector:
+          matchNames:
+          - esp-poller-production
+        endpoints:
+        - port: metrics
+          interval: 30s
+          scrapeTimeout: 10s
       # RabbitMQ Cluster Operator: with spec.tls the metrics listener is HTTPS on 15691 (port name prometheus-tls).
       # PodMonitor scrapes each StatefulSet replica; a Service-only scrape would round-robin one node per interval.
       additionalPodMonitors:


### PR DESCRIPTION
Added configuration files and resources for the esp-poller service, including deployment, config maps, and network policies. Updated kustomization files to include esp-poller resources and adjusted observability settings for Prometheus metrics scraping. This setup enables efficient monitoring and management of DIY ESP devices in the production environment.

## Description 💬

<!--- Describe your changes in detail -->
