### PR TITLE
feat(previews): add kustomization and resources for ddnsadmin preview…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -116,6 +116,8 @@ updates:
   - "/clusters/production/apps/previews/clutterstock"
   - "/clusters/production/apps/previews/clutterstock/base"
   - "/clusters/production/apps/previews/clutterstock/databases"
+  - "/clusters/production/apps/previews/ddnsadmin"
+  - "/clusters/production/apps/previews/ddnsadmin/base"
   - "/clusters/production/apps/shared/production"
   - "/clusters/production/flux-system"
   schedule:

--- a/clusters/production/apps/previews/ddnsadmin/base/cilium-cluster-nodes-to-http.yaml
+++ b/clusters/production/apps/previews/ddnsadmin/base/cilium-cluster-nodes-to-http.yaml
@@ -1,0 +1,18 @@
+# Allow cluster nodes (host networking, e.g. kubelet probes through node IPs) to reach the preview
+# pod on port 8000. Mirrors the clutterstock preview pattern.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cluster-nodes-to-ddnsadmin-http
+spec:
+  endpointSelector:
+    matchLabels:
+      app: ddnsadmin
+  ingress:
+  - fromEntities:
+    - host
+    - remote-node
+    toPorts:
+    - ports:
+      - port: "8000"
+        protocol: TCP

--- a/clusters/production/apps/previews/ddnsadmin/base/deployment.yaml
+++ b/clusters/production/apps/previews/ddnsadmin/base/deployment.yaml
@@ -1,0 +1,102 @@
+# Ephemeral preview-env Deployment for ddnsadmin. Namespace + image tag/digest are set per-PR by
+# the overlay; WEB_PREFIX is patched per-PR to the preview hostname.
+#
+# This is the QA/demo image (scripts/start.sh), which at startup: `apk add bind` (needs egress to
+# the alpine CDN), provisions BIND listening on 127.0.0.1:53, seeds the example.com zone + tsig-key,
+# creates the admin/5MNU6Zk4wyfhWg7n superuser, runs `manage.py axfr`, collectstatic, then
+# `runserver 0.0.0.0:8000`. Everything (DNS + sqlite) lives inside the one container — data is
+# ephemeral per pod. ddnsadmin's CLAUDE.md explicitly says this image is not a production model.
+#
+# SECURITY / HARDENING — needs owner review (this tree is a draft):
+#   * Runs as root and binds 127.0.0.1:53; `named -u named` then drops privileges. A "restricted"
+#     PodSecurity / Kyverno admission policy will likely reject this. Either relax PSS for the
+#     `ddnsadmin.wsh.no/preview=true` namespaces or rework the image to run rootless before enabling.
+#   * Root filesystem must be writable (BIND config under /etc/bind, /var/bind, sqlite db, static).
+#   * Startup does `apk add` from the internet — the NetworkPolicy egress allows 0.0.0.0/0:443.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ddnsadmin
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ddnsadmin
+  template:
+    metadata:
+      labels:
+        app: ddnsadmin
+        app.kubernetes.io/name: ddnsadmin
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        # QA/demo image runs as root (BIND binds :53, chowns zone files). See hardening note above.
+        runAsNonRoot: false
+        runAsUser: 0
+      containers:
+      - name: ddnsadmin
+        image: ghcr.io/hwinther/ddnsadmin/ddnsadmin:placeholder
+        imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            # Drop the broad set but keep what start.sh + named -u need: bind :53, chown zone
+            # files, and named's setuid/setgid privilege drop.
+            drop:
+            - ALL
+            add:
+            - NET_BIND_SERVICE
+            - CHOWN
+            - DAC_OVERRIDE
+            - FOWNER
+            - SETUID
+            - SETGID
+        env:
+        # Allow the preview Host header (settings.py defaults to localhost-only; DEBUG=True does not
+        # auto-allow because ALLOWED_HOSTS is non-empty). Wildcard is acceptable for a short-lived
+        # preview behind the LAN TLS terminator.
+        - name: ALLOWED_HOSTS
+          value: "*"
+        # Patched per-PR by the overlay to https://ddnsadmin-<PR>.preview.wsh.no.
+        - name: WEB_PREFIX
+          value: "https://ddnsadmin-preview.preview.wsh.no"
+        ports:
+        - name: http
+          containerPort: 8000
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        # Startup is slow (apk add + migrate + axfr + collectstatic); gate readiness behind a
+        # generous startupProbe so the pod isn't killed mid-bootstrap.
+        startupProbe:
+          httpGet:
+            path: /ddnsadmin/login/
+            port: http
+          periodSeconds: 5
+          failureThreshold: 60
+        readinessProbe:
+          httpGet:
+            path: /ddnsadmin/login/
+            port: http
+          periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ddnsadmin
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8000
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: ddnsadmin

--- a/clusters/production/apps/previews/ddnsadmin/base/ingress.yaml
+++ b/clusters/production/apps/previews/ddnsadmin/base/ingress.yaml
@@ -1,0 +1,20 @@
+# Host is patched per-PR by the overlay (ddnsadmin-<N>.preview.wsh.no). entrypoints: web because
+# the LAN nginx fronting the cluster terminates TLS with the existing *.preview.wsh.no wildcard cert.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ddnsadmin
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+  rules:
+  - host: ddnsadmin-preview.preview.wsh.no
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: ddnsadmin
+            port:
+              number: 8000

--- a/clusters/production/apps/previews/ddnsadmin/base/kustomization.yaml
+++ b/clusters/production/apps/previews/ddnsadmin/base/kustomization.yaml
@@ -1,0 +1,10 @@
+# Shared kustomize base for ddnsadmin PR preview environments. Every per-PR overlay under
+# ../pr-<N>/ references this base. Resources here intentionally have no `metadata.namespace` so the
+# overlay's `namespace:` directive populates it.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+- ingress.yaml
+- networkpolicies.yaml
+- cilium-cluster-nodes-to-http.yaml

--- a/clusters/production/apps/previews/ddnsadmin/base/networkpolicies.yaml
+++ b/clusters/production/apps/previews/ddnsadmin/base/networkpolicies.yaml
@@ -1,0 +1,41 @@
+# Single-pod app: BIND + Django live in the same container and talk over 127.0.0.1, so there is no
+# cross-pod DNS-update traffic. Ingress is just traefik -> :8000; egress needs kube-dns + general
+# internet (startup `apk add bind` pulls from the alpine CDN over 443).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ddnsadmin
+spec:
+  podSelector:
+    matchLabels:
+      app: ddnsadmin
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: traefik
+    ports:
+    - port: 8000
+      protocol: TCP
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+  # Startup pulls the `bind` apk package from the public alpine CDN; block link-local metadata.
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 169.254.169.254/32

--- a/clusters/production/apps/previews/ddnsadmin/kustomization.yaml
+++ b/clusters/production/apps/previews/ddnsadmin/kustomization.yaml
@@ -1,0 +1,11 @@
+# Parent kustomization for ddnsadmin preview environments. Maintained by the
+# `gitops-preview-upsert.yml` / `gitops-preview-teardown.yml` reusable workflows in
+# `hwinther/reusable-workflows`. The workflows add/remove `pr-<N>` entries below as PRs labelled
+# `deploy-feature` are opened/closed in `hwinther/ddnsadmin`.
+#
+# Unlike clutterstock there is no `databases` entry: ddnsadmin's preview image is self-contained
+# (BIND + sqlite + seeded example.com zone baked in by scripts/start.sh), so there is no per-PR
+# CNPG database and no template/database.yaml.tpl in this tree.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/clusters/production/apps/previews/ddnsadmin/template/README.md
+++ b/clusters/production/apps/previews/ddnsadmin/template/README.md
@@ -1,0 +1,34 @@
+# Preview-env templates (ddnsadmin)
+
+These files are read by `gitops-preview-upsert.yml` (in `hwinther/reusable-workflows`) and
+substituted to produce the per-PR overlay. Placeholders use `__PLACEHOLDER__` syntax and the
+workflow substitutes via `sed`.
+
+ddnsadmin is a **single-image** app whose preview image is self-contained (BIND + sqlite + seeded
+`example.com` zone baked in by `scripts/start.sh`). Unlike clutterstock there is **no per-PR
+database**: this tree intentionally has no `database.yaml.tpl` and no `databases/` subtree, so the
+upsert workflow's database step no-ops.
+
+Files the workflow renders per PR:
+
+| Template | Renders to | Purpose |
+|---|---|---|
+| `overlay.namespace.yaml.tpl` | `../pr-<N>/namespace.yaml` | Per-PR Namespace |
+| `overlay.kustomization.yaml.tpl` | `../pr-<N>/kustomization.yaml` | Per-PR kustomize overlay |
+
+Placeholders the workflow replaces:
+
+- `__PR__` — PR number (e.g. `42`)
+- `__HOST__` — preview hostname (e.g. `ddnsadmin-42.preview.wsh.no`)
+- `__IMAGE_TAG__` — single-image tag (e.g. `0.10.1-pr.42`)
+- `__IMAGE_DIGEST__` — single-image digest (e.g. `sha256:abc...`)
+
+The multi-image placeholders (`__IMAGE_API_*__`, etc.) and `__DB_NAME__` are unused here.
+
+Editing a template here does not retroactively update existing previews — re-run the workflow on
+each open PR (push a commit or re-apply the `deploy-feature` label) to roll templates forward.
+
+> **Draft — needs review before first deploy.** The QA/demo image runs as root and binds `:53` for
+> BIND. A restricted PodSecurity / Kyverno admission policy will likely reject it. Either relax PSS
+> for `ddnsadmin.wsh.no/preview=true` namespaces or rework the image to run rootless. See the
+> hardening note in `base/deployment.yaml`.

--- a/clusters/production/apps/previews/ddnsadmin/template/overlay.kustomization.yaml.tpl
+++ b/clusters/production/apps/previews/ddnsadmin/template/overlay.kustomization.yaml.tpl
@@ -1,0 +1,49 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ddnsadmin-preview-pr-__PR__
+
+resources:
+- ../base
+- namespace.yaml
+
+# `labels` (vs deprecated `commonLabels`) with includeSelectors: false avoids leaking the PR label
+# into NetworkPolicy podSelectors that target peers in other namespaces (kube-dns, traefik).
+labels:
+- pairs:
+    ddnsadmin.wsh.no/pr: "__PR__"
+  includeSelectors: false
+  includeTemplates: true
+
+# Single image: digest pins the deploy to exactly the artifact that just passed e2e + grype; the
+# tag (newTag) is kept alongside so `kubectl get deploy -o yaml | grep image:` stays readable.
+images:
+- name: ghcr.io/hwinther/ddnsadmin/ddnsadmin
+  newTag: "__IMAGE_TAG__"
+  digest: "__IMAGE_DIGEST__"
+
+patches:
+# WEB_PREFIX drives the absolute URLs Django emits (django-environ reads it in dweb/settings.py),
+# so it must point at the per-PR preview host. The ingress host is rewritten to match.
+- target:
+    kind: Deployment
+    name: ddnsadmin
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: ddnsadmin
+    spec:
+      template:
+        spec:
+          containers:
+          - name: ddnsadmin
+            env:
+            - name: WEB_PREFIX
+              value: "https://__HOST__"
+- target:
+    kind: Ingress
+    name: ddnsadmin
+  patch: |-
+    - op: replace
+      path: /spec/rules/0/host
+      value: __HOST__

--- a/clusters/production/apps/previews/ddnsadmin/template/overlay.namespace.yaml.tpl
+++ b/clusters/production/apps/previews/ddnsadmin/template/overlay.namespace.yaml.tpl
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ddnsadmin-preview-pr-__PR__
+  labels:
+    app.kubernetes.io/part-of: ddnsadmin
+    ddnsadmin.wsh.no/preview: "true"
+    ddnsadmin.wsh.no/pr: "__PR__"


### PR DESCRIPTION
… environments

- Introduced a new kustomization setup for ddnsadmin, enabling per-PR preview environments.
- Added deployment, ingress, and network policies to manage the preview application.
- Configured Cilium network policies to allow cluster nodes to access the preview pod.
- Created templates for dynamic namespace and overlay generation based on PR context.
- Documented the preview environment setup in a new README file.

## Description 💬

<!--- Describe your changes in detail -->
