### PR TITLE
feat: update AIS-catcher deployment and configuration for MQTT support

### DIFF
--- a/clusters/edge-sdr/apps/ais-catcher-edge-sdr/README.md
+++ b/clusters/edge-sdr/apps/ais-catcher-edge-sdr/README.md
@@ -23,6 +23,7 @@ Use the Secret for **exact positions** (`LAT`, `LON`) so coordinates are not com
 | `LAT`                   | Station latitude (decimal degrees); overrides ConfigMap.                                                                          |
 | `LON`                   | Station longitude (decimal degrees); overrides ConfigMap.                                                                         |
 | `EXTRA_ARGS`            | Extra CLI flags for AIS-catcher (e.g. `-u host port key`, `-Q mqtt://...`).                                                       |
+| `MQTT_PASSWORD`         | Password for the `ais-catcher` Mosquitto user (see [MQTT publishing](#mqtt-publishing)). Keep alphanumeric (goes in the broker URL). |
 | Any other ConfigMap key | Same names as in **`ais-catcher-env`** (`DEVICE_INDEX`, `STATION_URL`, `BIASTEE`, …) if you need to override without editing Git. |
 
 ### Example: create the Secret
@@ -46,3 +47,31 @@ kubectl create secret generic ais-catcher-secret -n ais-catcher-edge-sdr \
 To rotate, replace the Secret (e.g. delete and recreate, or `kubectl create secret ... --dry-run=client -o yaml | kubectl apply -f -` with a manifest generated locally and **never** committed).
 
 Do **not** commit files that contain real credentials. Use the commands above, Sealed Secrets, SOPS, or External Secrets instead.
+
+## MQTT publishing
+
+AIS-catcher publishes each decoded message to the production **Mosquitto** broker so other apps can
+consume the stream (not Home Assistant — generic data pipeline). The image's start script enables it
+when `MQTT_HOST` is set; non-secret settings are in [`configmap-ais-catcher-env.yaml`](configmap-ais-catcher-env.yaml):
+
+| Setting | Default | Notes |
+| --- | --- | --- |
+| `MQTT_HOST` | `10.20.13.100` | Mosquitto LoadBalancer VIP (reachable from the edge LAN). |
+| `MQTT_PORT` | `1883` | Plain MQTT (no TLS listener yet). |
+| `MQTT_USERNAME` | `ais-catcher` | Must exist in the mosquitto passwd file — see [mosquitto-secrets.md](../../../production/apps/mosquitto-production/mosquitto-secrets.md). |
+| `MQTT_PASSWORD` | — | **Secret only** (`ais-catcher-secret`). Keep alphanumeric (embedded in the broker URL). |
+| `MQTT_TOPIC` | `ais/data` | Supports templates, e.g. `ais/%mmsi%` or `ais/%type%/%mmsi%`. |
+| `MQTT_MSGFORMAT` | `JSON_FULL` | One of NMEA, NMEA_TAG, FULL, JSON_NMEA, JSON_SPARSE, JSON_FULL. |
+
+Prerequisites: (1) a new image build with MQTT support in the start script
+(`hwinther/wsh-rtl-sdr`), then bump the tag/digest in [ais-catcher-deployment.yaml](ais-catcher-deployment.yaml);
+(2) create the `ais-catcher` mosquitto user and put its password in `ais-catcher-secret`:
+
+```bash
+kubectl create secret generic ais-catcher-secret -n ais-catcher-edge-sdr \
+  --from-literal=EXTRA_ARGS='-u hub.shipxplorer.com 37615 YOUR_API_KEY' \
+  --from-literal=MQTT_PASSWORD='YourAlphanumericPassword'
+```
+
+Inspect the live stream with the `mqttui` web UI in `mosquitto-production`, or
+`mosquitto_sub -h 10.20.13.100 -u ais-catcher -P '…' -t 'ais/#' -v`.

--- a/clusters/edge-sdr/apps/ais-catcher-edge-sdr/ais-catcher-deployment.yaml
+++ b/clusters/edge-sdr/apps/ais-catcher-edge-sdr/ais-catcher-deployment.yaml
@@ -42,7 +42,7 @@ spec:
                 - "true"
       containers:
       - name: ais-catcher
-        image: ghcr.io/hwinther/wsh-rtl-sdr/ais-catcher:0.4.0@sha256:bd93f370670fb9d618ef1ff958255f326e4d249f959352410b87b7d219771382
+        image: ghcr.io/hwinther/wsh-rtl-sdr/ais-catcher:0.4.1@sha256:f268101e0b6e7de5f03a5d34e5f4302b3029d2d114936bfb19a191beecb0f78c
         imagePullPolicy: IfNotPresent
         # ConfigMap first, then Secret: same key in both → Secret wins (good for API keys / EXTRA_ARGS).
         # Create Secret manually (or ExternalSecrets / SOPS); optional so the pod runs without it.

--- a/clusters/edge-sdr/apps/ais-catcher-edge-sdr/configmap-ais-catcher-env.yaml
+++ b/clusters/edge-sdr/apps/ais-catcher-edge-sdr/configmap-ais-catcher-env.yaml
@@ -14,3 +14,11 @@ data:
   STATION_URL: "https://ais.edge-sdr.wsh.no"
   AIS_CATCHER_PORT: "8080"
   EXTRA_ARGS: ""
+  # MQTT publishing to the production Mosquitto broker (LB VIP, reachable from the edge LAN).
+  # Non-secret settings live here; MQTT_PASSWORD lives in `ais-catcher-secret` (see README.md).
+  # Requires an `ais-catcher` user in the mosquitto passwd file (mosquitto-secrets.md).
+  MQTT_HOST: "10.20.13.100"
+  MQTT_PORT: "1883"
+  MQTT_USERNAME: "ais-catcher"
+  MQTT_TOPIC: "ais/data"
+  MQTT_MSGFORMAT: "JSON_FULL"

--- a/clusters/production/apps/mosquitto-production/mosquitto-secrets.md
+++ b/clusters/production/apps/mosquitto-production/mosquitto-secrets.md
@@ -13,12 +13,17 @@ HA_USER=homeassistant
 HA_PW="$(openssl rand -base64 24 | tr -d '\n')"
 ESP_USER=esp
 ESP_PW="$(openssl rand -base64 24 | tr -d '\n')"
+# AIS-catcher (edge-sdr) publishes the AIS stream here. Keep it ALPHANUMERIC — it goes in the
+# broker URL (mqtt://user:pass@host) in AIS-catcher's -Q flag, which can't take @ : / in userinfo.
+AIS_USER=ais-catcher
+AIS_PW="$(openssl rand -hex 18)"
 
 # Build the passwd file with the same image the broker uses.
 docker run --rm --entrypoint sh eclipse-mosquitto:2.0.20 -c '
   touch /tmp/passwd
   mosquitto_passwd -b /tmp/passwd '"$HA_USER"' '"$HA_PW"'
   mosquitto_passwd -b /tmp/passwd '"$ESP_USER"' '"$ESP_PW"'
+  mosquitto_passwd -b /tmp/passwd '"$AIS_USER"' '"$AIS_PW"'
   cat /tmp/passwd' > passwd
 
 kubectl create secret generic mosquitto-auth \
@@ -31,7 +36,9 @@ rm -f passwd
 Record `HA_USER`/`HA_PW` — they go into Home Assistant's MQTT config entry
 (broker `mosquitto.mosquitto-production.svc.cluster.local`, port `1883`).
 `ESP_USER`/`ESP_PW` go into ESP/Tasmota/ESPHome firmware (broker
-`10.20.13.100`, port `1883`).
+`10.20.13.100`, port `1883`). `AIS_USER`/`AIS_PW` go into the `ais-catcher-secret`
+(`MQTT_PASSWORD`) in `ais-catcher-edge-sdr` — see
+[ais-catcher README](../../../edge-sdr/apps/ais-catcher-edge-sdr/README.md#mqtt-publishing).
 
 To add/rotate a user later: regenerate the file the same way and
 `kubectl create secret ... --dry-run=client -o yaml | kubectl apply -f -`, then


### PR DESCRIPTION
Updated the AIS-catcher deployment to use version 0.4.1 of the Docker image. Added new environment variables for MQTT configuration in the ConfigMap, including MQTT host, port, username, topic, and message format. Enhanced the README with details on MQTT publishing and prerequisites for setup, ensuring users can easily configure and utilize the new features.

## Description 💬

<!--- Describe your changes in detail -->
