### PR TITLE
feat: enhance observability with Prometheus monitoring for Mosquitto …

### DIFF
--- a/clusters/production/apps/cert-manager/install/cert-manager-helmrelease.yaml
+++ b/clusters/production/apps/cert-manager/install/cert-manager-helmrelease.yaml
@@ -36,6 +36,17 @@ spec:
     global:
       commonLabels:
         app.kubernetes.io/part-of: cert-manager-production
+    # Expose the controller's metrics (port 9402) to Prometheus. The chart's ServiceMonitor lives in
+    # the cert-manager namespace; the obs-kps Prometheus watches all namespaces but requires the
+    # release=obs-kps label to select it (serviceMonitorSelector). Rules: prometheusrule-cert-manager.yaml.
+    prometheus:
+      enabled: true
+      servicemonitor:
+        enabled: true
+        labels:
+          release: obs-kps
+        interval: 60s
+        scrapeTimeout: 30s
     resources:
       requests:
         cpu: 50m

--- a/clusters/production/apps/mosquitto-production/kustomization.yaml
+++ b/clusters/production/apps/mosquitto-production/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - namespace.yaml
 - mosquitto-configmap.yaml
 - mosquitto-statefulset.yaml
+- mosquitto-podmonitor.yaml
 - cilium-mqtt-ingress.yaml
 - kyverno-rbac-generate-pbs-encryption-keyfile.yaml
 - mosquitto-pbs-backup-cronjob.yaml

--- a/clusters/production/apps/mosquitto-production/mosquitto-podmonitor.yaml
+++ b/clusters/production/apps/mosquitto-production/mosquitto-podmonitor.yaml
@@ -1,0 +1,19 @@
+# Scrapes the mosquitto-exporter sidecar (port metrics/9234 on the broker pod). release=obs-kps so the
+# obs-kps Prometheus podMonitorSelector picks it up (it watches all namespaces). Operator sets the
+# series job label to <namespace>/<name> → job="mosquitto-production/mosquitto"
+# (used by the MosquittoDown rule in ../observability/prometheusrule-mosquitto.yaml).
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: mosquitto
+  namespace: mosquitto-production
+  labels:
+    release: obs-kps
+spec:
+  selector:
+    matchLabels:
+      app: mosquitto
+  podMetricsEndpoints:
+  - port: metrics
+    interval: 30s
+    scrapeTimeout: 10s

--- a/clusters/production/apps/mosquitto-production/mosquitto-secrets.md
+++ b/clusters/production/apps/mosquitto-production/mosquitto-secrets.md
@@ -22,6 +22,10 @@ AIS_PW="$(openssl rand -hex 18)"
 # adsb-mqtt (edge-sdr) publishes dump1090-fa's aircraft.json snapshots here.
 ADSB_USER=adsb
 ADSB_PW="$(openssl rand -hex 18)"
+# mosquitto-exporter sidecar subscribes to $SYS/# to expose Prometheus metrics. No ACL file is in use,
+# so any authenticated user can read $SYS — a dedicated read-only user keeps it auditable/rotatable.
+MON_USER=monitor
+MON_PW="$(openssl rand -base64 24 | tr -d '\n')"
 
 # Build the passwd file with the same image the broker uses.
 docker run --rm --entrypoint sh eclipse-mosquitto:2.0.20 -c '
@@ -31,6 +35,7 @@ docker run --rm --entrypoint sh eclipse-mosquitto:2.0.20 -c '
   mosquitto_passwd -b /tmp/passwd '"$MQTTUI_USER"' '"$MQTTUI_PW"'
   mosquitto_passwd -b /tmp/passwd '"$AIS_USER"' '"$AIS_PW"'
   mosquitto_passwd -b /tmp/passwd '"$ADSB_USER"' '"$ADSB_PW"'
+  mosquitto_passwd -b /tmp/passwd '"$MON_USER"' '"$MON_PW"'
   cat /tmp/passwd' > passwd
 
 kubectl create secret generic mosquitto-auth \
@@ -38,6 +43,13 @@ kubectl create secret generic mosquitto-auth \
   --from-file=passwd=./passwd
 
 rm -f passwd
+
+# The exporter sidecar reads its login from a separate Secret (envFrom MQTT_USER/MQTT_PASS). These
+# values are NOT the password file — they're the plaintext monitor credentials the exporter logs in with.
+kubectl create secret generic mosquitto-exporter-auth \
+  --namespace mosquitto-production \
+  --from-literal=username="$MON_USER" \
+  --from-literal=password="$MON_PW"
 ```
 
 Record `HA_USER`/`HA_PW` — they go into Home Assistant's MQTT config entry
@@ -48,6 +60,8 @@ Record `HA_USER`/`HA_PW` — they go into Home Assistant's MQTT config entry
 [ais-catcher README](../../../edge-sdr/apps/ais-catcher-edge-sdr/README.md#mqtt-publishing).
 `ADSB_USER`/`ADSB_PW` go into the `adsb-mqtt-secret` (`MQTT_PASSWORD`) in `adsb-edge-sdr` — see
 [adsb README](../../../edge-sdr/apps/adsb-edge-sdr/README.md#mqtt-publishing).
+`MON_USER`/`MON_PW` are consumed only by the `mosquitto-exporter-auth` Secret above (the
+mosquitto-exporter sidecar) — no other system needs them.
 
 To add/rotate a user later: regenerate the file the same way and
 `kubectl create secret ... --dry-run=client -o yaml | kubectl apply -f -`, then

--- a/clusters/production/apps/mosquitto-production/mosquitto-statefulset.yaml
+++ b/clusters/production/apps/mosquitto-production/mosquitto-statefulset.yaml
@@ -101,6 +101,54 @@ spec:
           readOnly: true
         - name: data
           mountPath: /mosquitto/data
+      # Prometheus exporter sidecar: subscribes to $SYS/# over loopback and exposes broker metrics
+      # (broker_clients_connected, broker_uptime, broker_messages_*) on :9234. Scraped by the
+      # `mosquitto` PodMonitor; alerts in observability/prometheusrule-mosquitto.yaml. Auth comes from
+      # the `monitor` broker user via the mosquitto-exporter-auth Secret (see mosquitto-secrets.md);
+      # the Secret is optional so the pod still starts before it exists (metrics just stay empty until
+      # the broker accepts the login).
+      - name: exporter
+        image: docker.io/sapcc/mosquitto-exporter:0.8.0
+        imagePullPolicy: IfNotPresent
+        args:
+        - --endpoint
+        - tcp://localhost:1883
+        env:
+        - name: MQTT_USER
+          valueFrom:
+            secretKeyRef:
+              name: mosquitto-exporter-auth
+              key: username
+              optional: true
+        - name: MQTT_PASS
+          valueFrom:
+            secretKeyRef:
+              name: mosquitto-exporter-auth
+              key: password
+              optional: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        ports:
+        - name: metrics
+          containerPort: 9234
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 5
+          periodSeconds: 15
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
       volumes:
       - name: config
         configMap:

--- a/clusters/production/apps/observability/flux-podmonitor.yaml
+++ b/clusters/production/apps/observability/flux-podmonitor.yaml
@@ -1,0 +1,26 @@
+# Scrapes the Flux controllers' Prometheus metrics (port http-prom / 8080 on the controller pods).
+# The flux-system Services only expose the controllers' HTTP API on port 80 — NOT the metrics port —
+# so a ServiceMonitor can't reach metrics; a PodMonitor against the pods is the supported path
+# (mirrors fluxcd/flux2-monitoring-example). This object is forced into observability-production by
+# the kustomization's namespace transformer, so namespaceSelector points it back at flux-system.
+# Picked up by the operator via the release=obs-kps label (Prometheus podMonitorSelector).
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: flux
+  labels:
+    release: obs-kps
+spec:
+  namespaceSelector:
+    matchNames:
+    - flux-system
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: flux
+      control-plane: controller
+  podMetricsEndpoints:
+  # Operator sets the series `job` label to <podmonitor-namespace>/<name>. This object is namespaced
+  # into observability-production → job="observability-production/flux" (FluxControllerDown rule).
+  - port: http-prom
+    interval: 60s
+    scrapeTimeout: 20s

--- a/clusters/production/apps/observability/kustomization.yaml
+++ b/clusters/production/apps/observability/kustomization.yaml
@@ -20,6 +20,13 @@ resources:
 - prometheusrule-ceph.yaml
 - prometheusrule-postgres-cnpg.yaml
 - prometheusrule-rabbitmq.yaml
+# Tier-2 custom alerting: Flux GitOps health (controllers are otherwise unscraped — flux-podmonitor.yaml),
+# cert-manager TLS expiry/renewal (scrape enabled via the cert-manager HelmRelease values), and Mosquitto
+# (metrics from the exporter sidecar + PodMonitor in mosquitto-production).
+- flux-podmonitor.yaml
+- prometheusrule-flux.yaml
+- prometheusrule-cert-manager.yaml
+- prometheusrule-mosquitto.yaml
 - minio-deployment.yaml
 - minio-buckets-job.yaml
 

--- a/clusters/production/apps/observability/prometheusrule-cert-manager.yaml
+++ b/clusters/production/apps/observability/prometheusrule-cert-manager.yaml
@@ -1,0 +1,50 @@
+# cert-manager TLS health. Metrics come from the cert-manager controller (port 9402), scraped via the
+# chart's ServiceMonitor enabled in ../cert-manager/install/cert-manager-helmrelease.yaml. Not covered
+# by kube-prometheus-stack defaults. release=obs-kps so the operator ruleSelector picks it up.
+#
+# An expired or failed-to-renew cert is a user-visible TLS outage on *.wsh.no, so these matter even
+# though renewals are automatic — they catch the case where automation itself breaks (ACME/DNS-01,
+# rate limits, issuer misconfig).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cert-manager
+  labels:
+    release: obs-kps
+spec:
+  groups:
+  - name: cert-manager
+    rules:
+    # 7–21 days to expiry: renewal should have happened by now (cert-manager renews at 2/3 of lifetime,
+    # typically ~30d out for 90d Let's Encrypt certs). Warning window stops at 7d so it never overlaps
+    # the critical rule below (no double-page).
+    - alert: CertManagerCertExpiringSoon
+      expr: |
+        (certmanager_certificate_expiration_timestamp_seconds - time()) < 1814400
+          and
+        (certmanager_certificate_expiration_timestamp_seconds - time()) >= 604800
+      for: 1h
+      labels:
+        severity: warning
+      annotations:
+        summary: "TLS cert {{ $labels.namespace }}/{{ $labels.name }} expires in {{ $value | humanizeDuration }}"
+        description: "Certificate {{ $labels.namespace }}/{{ $labels.name }} expires in {{ $value | humanizeDuration }} and has not renewed. Check `kubectl describe certificate -n {{ $labels.namespace }} {{ $labels.name }}` and the issuer/ACME order."
+    # <7 days: renewal is clearly broken — imminent outage.
+    - alert: CertManagerCertExpiringCritical
+      expr: (certmanager_certificate_expiration_timestamp_seconds - time()) < 604800
+      for: 1h
+      labels:
+        severity: critical
+      annotations:
+        summary: "TLS cert {{ $labels.namespace }}/{{ $labels.name }} expires in {{ $value | humanizeDuration }}"
+        description: "Certificate {{ $labels.namespace }}/{{ $labels.name }} expires in {{ $value | humanizeDuration }} and renewal has NOT succeeded — imminent TLS failure. Inspect the Certificate, CertificateRequest, and Order/Challenge resources."
+    # The Certificate's Ready condition is False — issuance or renewal is actively failing (independent
+    # of how close expiry is; catches a cert that never issued in the first place).
+    - alert: CertManagerCertNotReady
+      expr: certmanager_certificate_ready_status{condition="True"} == 0
+      for: 1h
+      labels:
+        severity: warning
+      annotations:
+        summary: "TLS cert {{ $labels.namespace }}/{{ $labels.name }} not Ready"
+        description: "Certificate {{ $labels.namespace }}/{{ $labels.name }} has Ready!=True for >1h — issuance/renewal is failing. Check its CertificateRequest and Order for the error."

--- a/clusters/production/apps/observability/prometheusrule-flux.yaml
+++ b/clusters/production/apps/observability/prometheusrule-flux.yaml
@@ -1,0 +1,49 @@
+# Flux GitOps health. Metrics come from flux-podmonitor.yaml (gotk_* series exported by the
+# kustomize/helm/source/notification controllers). Not covered by kube-prometheus-stack defaults.
+# release=obs-kps so the operator ruleSelector picks it up.
+#
+# NOTE on labels: the gotk_* series carry the *reconciled object's* namespace in `namespace`, but the
+# PodMonitor target also has a `namespace` label (flux-system). With default honor_labels=false the
+# scraped one is renamed → the object namespace appears as `exported_namespace`. Rules group on that.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: flux-gitops
+  labels:
+    release: obs-kps
+spec:
+  groups:
+  - name: flux-gitops
+    rules:
+    # A Kustomization/HelmRelease/GitRepository/etc. stuck not-Ready for >15m: drift is no longer being
+    # applied. 15m absorbs normal transient retries (e.g. a HelmRelease upgrade in progress).
+    - alert: FluxReconciliationFailure
+      expr: max by (exported_namespace, name, kind) (gotk_reconcile_condition{type="Ready",status="False"}) == 1
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Flux {{ $labels.kind }} {{ $labels.exported_namespace }}/{{ $labels.name }} failing to reconcile"
+        description: "{{ $labels.kind }} {{ $labels.exported_namespace }}/{{ $labels.name }} has had Ready=False for >15m — GitOps is no longer converging this resource. Check `flux get all -A` / controller logs."
+    # All of a controller's metrics endpoints are unreachable → that controller is down/crashlooping
+    # and nothing it owns reconciles. The operator sets the job label to <podmonitor-namespace>/<name>;
+    # flux-podmonitor.yaml is forced into observability-production by the kustomization → this job name.
+    - alert: FluxControllerDown
+      expr: up{job="observability-production/flux"} == 0
+      for: 10m
+      labels:
+        severity: critical
+      annotations:
+        summary: "Flux controller {{ $labels.pod }} is down"
+        description: "Flux controller pod {{ $labels.pod }} has been unscrapeable for >10m. While down, the resources it owns are not reconciled."
+    # Suspended = reconciliation intentionally paused (`flux suspend`). Usually deliberate during
+    # maintenance/debugging, so this is info (non-paging via the severity=~info|none → null route) and
+    # fires only after 2h to catch a suspend someone forgot to lift.
+    - alert: FluxResourceSuspended
+      expr: max by (exported_namespace, name, kind) (gotk_suspend_status) == 1
+      for: 2h
+      labels:
+        severity: info
+      annotations:
+        summary: "Flux {{ $labels.kind }} {{ $labels.exported_namespace }}/{{ $labels.name }} suspended >2h"
+        description: "Reconciliation has been suspended for >2h — Git changes to this resource are not being applied. Run `flux resume {{ $labels.kind | lower }} -n {{ $labels.exported_namespace }} {{ $labels.name }}` if unintended."

--- a/clusters/production/apps/observability/prometheusrule-mosquitto.yaml
+++ b/clusters/production/apps/observability/prometheusrule-mosquitto.yaml
@@ -1,0 +1,35 @@
+# Mosquitto MQTT broker health. Metrics come from the mosquitto-exporter sidecar (see
+# ../mosquitto-production/mosquitto-statefulset.yaml), scraped by the `mosquitto` PodMonitor in
+# mosquitto-production. release=obs-kps so the operator ruleSelector picks it up.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: mosquitto
+  labels:
+    release: obs-kps
+spec:
+  groups:
+  - name: mosquitto
+    rules:
+    # Exporter's /metrics endpoint unscrapeable → the broker pod is down/crashlooping. HA, the ESP
+    # devices, and the AIS/ADSB publishers all lose their broker. job set by PodMonitor namespace/name.
+    - alert: MosquittoDown
+      expr: up{job="mosquitto-production/mosquitto"} == 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: "Mosquitto MQTT broker is down"
+        description: "The mosquitto-exporter on {{ $labels.pod }} has been unscrapeable for >5m — the broker is likely down. MQTT clients (Home Assistant, ESP devices, AIS/ADSB feeds) cannot publish or subscribe."
+    # broker_clients_connected counts the exporter's own loopback session, so the floor is 1. Dropping
+    # to <=1 means every other client (HA, ESP, ais-catcher, adsb-mqtt) has disconnected — a broker or
+    # auth/networking fault rather than a single noisy client. (If the exporter itself can't authenticate
+    # the series is absent, not 0 — that case shows up as missing metrics, with MosquittoDown unaffected.)
+    - alert: MosquittoNoExternalClients
+      expr: broker_clients_connected <= 1
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Mosquitto has no clients beyond the exporter"
+        description: "broker_clients_connected has been <=1 for >15m — only the metrics exporter is connected; all publishers/subscribers have dropped. Check the broker, the mosquitto LB VIP (10.20.13.100), and the AIS/ADSB feeder pods."


### PR DESCRIPTION
…and Flux

- Added a PodMonitor for Mosquitto to scrape metrics from the exporter sidecar, enabling health checks and alerts for broker status.
- Introduced PrometheusRules for Mosquitto and Flux to monitor their operational health, including alerts for broker downtime and reconciliation failures.
- Updated kustomization files to include new monitoring resources for better observability of the Mosquitto and Flux components.

## Description 💬

<!--- Describe your changes in detail -->
