### PR TITLE
feat: add blackbox-exporter for external endpoint monitoring

### DIFF
--- a/clusters/production/apps/observability/blackbox-probes.yaml
+++ b/clusters/production/apps/observability/blackbox-probes.yaml
@@ -1,0 +1,65 @@
+# External (internet-vantage) endpoint probing. The blackbox-exporter runs on the off-cluster VPS
+# (see infra/blackbox-vps/) so probes traverse the real public path — external DNS, the internet, the
+# nginx TLS front-end — catching user-facing failures the in-cluster metrics miss (e.g. the front-end
+# truncation incident). Prometheus reaches the VPS blackbox over the existing tunnel.
+#
+# prober.url must be the VPS's TUNNEL IP (not its public IP — the exporter binds to the tunnel only).
+# >>> REPLACE 10.0.0.0-PLACEHOLDER below with the VPS tunnel address before pushing. <<<
+#
+# release=obs-kps so the operator probeSelector picks these up. Each target series gets instance=<url>
+# and the probe_origin=vps-external label (used by prometheusrule-blackbox.yaml).
+#
+# mgmt endpoints are intentionally NOT probed: *.mgmt.wsh.no resolves to LAN IPs and is unreachable
+# from the internet by design.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: external-core-apps
+  namespace: observability-production
+  labels:
+    release: obs-kps
+spec:
+  interval: 60s
+  scrapeTimeout: 15s
+  # http_2xx module (defined in infra/blackbox-vps/blackbox.yml) requires HTTP 2xx + valid TLS.
+  module: http_2xx
+  prober:
+    url: 10.0.0.0-PLACEHOLDER:9115
+    scheme: http
+  targets:
+    staticConfig:
+      static:
+      - https://clutterstock.wsh.no
+      - https://www.wsh.no
+      labels:
+        probe_origin: vps-external
+---
+# Auth-gated / redirecting public services: an unauthenticated GET legitimately returns 200/3xx/401/403,
+# so the lenient http_public module treats those as success (still fails on 5xx / TLS errors / timeouts).
+# Re-bucket hosts between this and external-core-apps as you learn each one's real response.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: external-public-services
+  namespace: observability-production
+  labels:
+    release: obs-kps
+spec:
+  interval: 60s
+  scrapeTimeout: 15s
+  module: http_public
+  prober:
+    url: 10.0.0.0-PLACEHOLDER:9115
+    scheme: http
+  targets:
+    staticConfig:
+      static:
+      - https://auth.wsh.no
+      - https://ddns.wsh.no
+      - https://ddnsadmin.wsh.no
+      - https://node-red.wsh.no
+      - https://home-assistant.wsh.no
+      - https://rabbitmq.wsh.no
+      - https://pbs.wsh.no
+      labels:
+        probe_origin: vps-external

--- a/clusters/production/apps/observability/kube-state-metrics-flux-helmrelease.yaml
+++ b/clusters/production/apps/observability/kube-state-metrics-flux-helmrelease.yaml
@@ -1,0 +1,321 @@
+# Dedicated kube-state-metrics instance that emits ONLY Flux custom-resource state (gotk_resource_info)
+# via KSM's custom-resource-state feature. Flux v2.8 controllers don't export gotk_reconcile_condition,
+# so per-object Ready/suspended alerting (prometheusrule-flux.yaml) needs this.
+#
+# Why a separate instance and not the kube-prometheus-stack's bundled KSM: this config sets
+# `collectors: []` + `--custom-resource-state-only=true`, which would disable the standard kube_* metrics
+# that the bundled KSM provides (and that every default dashboard/alert depends on). Isolating it here
+# means a bad CR-state config can only break gotk_resource_info, nothing load-bearing.
+#
+# Config is the upstream fluxcd/flux2-monitoring-example CR-state config (GVK API versions verified
+# against the live CRDs). gotk_resource_info is an Info metric (value always 1); state lives in the
+# `ready` ("True"/"False"/"Unknown") and `suspended` labels, plus KSM's customresource_kind label.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ksm-flux
+  namespace: observability-production
+spec:
+  interval: 30m
+  timeout: 10m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: kube-state-metrics
+      version: "7.4.0"
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: observability-production
+  values:
+    # Flux-CR-only: no standard collectors (the bundled obs-kps KSM owns those).
+    collectors: []
+    extraArgs:
+    - --custom-resource-state-only=true
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        memory: 128Mi
+    # ServiceMonitor for the obs-kps Prometheus (selects on release=obs-kps).
+    prometheus:
+      monitor:
+        enabled: true
+        additionalLabels:
+          release: obs-kps
+    rbac:
+      extraRules:
+      - apiGroups:
+        - source.toolkit.fluxcd.io
+        - kustomize.toolkit.fluxcd.io
+        - helm.toolkit.fluxcd.io
+        - notification.toolkit.fluxcd.io
+        - image.toolkit.fluxcd.io
+        resources:
+        - gitrepositories
+        - buckets
+        - helmrepositories
+        - helmcharts
+        - ocirepositories
+        - kustomizations
+        - helmreleases
+        - alerts
+        - providers
+        - receivers
+        - imagerepositories
+        - imagepolicies
+        - imageupdateautomations
+        verbs: [ "list", "watch" ]
+    customResourceState:
+      enabled: true
+      config:
+        spec:
+          resources:
+          - groupVersionKind:
+              group: kustomize.toolkit.fluxcd.io
+              version: v1
+              kind: Kustomization
+            metricNamePrefix: gotk
+            metrics:
+            - name: "resource_info"
+              help: "The current state of a Flux Kustomization resource."
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    name: [ metadata, name ]
+              labelsFromPath:
+                exported_namespace: [ metadata, namespace ]
+                ready: [ status, conditions, "[type=Ready]", status ]
+                suspended: [ spec, suspend ]
+                revision: [ status, lastAppliedRevision ]
+                source_name: [ spec, sourceRef, name ]
+          - groupVersionKind:
+              group: helm.toolkit.fluxcd.io
+              version: v2
+              kind: HelmRelease
+            metricNamePrefix: gotk
+            metrics:
+            - name: "resource_info"
+              help: "The current state of a Flux HelmRelease resource."
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    name: [ metadata, name ]
+              labelsFromPath:
+                exported_namespace: [ metadata, namespace ]
+                ready: [ status, conditions, "[type=Ready]", status ]
+                suspended: [ spec, suspend ]
+                revision: [ status, history, "0", chartVersion ]
+                chart_name: [ status, history, "0", chartName ]
+                chart_app_version: [ status, history, "0", appVersion ]
+                chart_ref_name: [ spec, chartRef, name ]
+                chart_source_name: [ spec, chart, spec, sourceRef, name ]
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              version: v1
+              kind: GitRepository
+            metricNamePrefix: gotk
+            metrics:
+            - name: "resource_info"
+              help: "The current state of a Flux GitRepository resource."
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    name: [ metadata, name ]
+              labelsFromPath:
+                exported_namespace: [ metadata, namespace ]
+                ready: [ status, conditions, "[type=Ready]", status ]
+                suspended: [ spec, suspend ]
+                revision: [ status, artifact, revision ]
+                url: [ spec, url ]
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              version: v1
+              kind: Bucket
+            metricNamePrefix: gotk
+            metrics:
+            - name: "resource_info"
+              help: "The current state of a Flux Bucket resource."
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    name: [ metadata, name ]
+              labelsFromPath:
+                exported_namespace: [ metadata, namespace ]
+                ready: [ status, conditions, "[type=Ready]", status ]
+                suspended: [ spec, suspend ]
+                revision: [ status, artifact, revision ]
+                endpoint: [ spec, endpoint ]
+                bucket_name: [ spec, bucketName ]
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              version: v1
+              kind: HelmRepository
+            metricNamePrefix: gotk
+            metrics:
+            - name: "resource_info"
+              help: "The current state of a Flux HelmRepository resource."
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    name: [ metadata, name ]
+              labelsFromPath:
+                exported_namespace: [ metadata, namespace ]
+                ready: [ status, conditions, "[type=Ready]", status ]
+                suspended: [ spec, suspend ]
+                revision: [ status, artifact, revision ]
+                url: [ spec, url ]
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              version: v1
+              kind: HelmChart
+            metricNamePrefix: gotk
+            metrics:
+            - name: "resource_info"
+              help: "The current state of a Flux HelmChart resource."
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    name: [ metadata, name ]
+              labelsFromPath:
+                exported_namespace: [ metadata, namespace ]
+                ready: [ status, conditions, "[type=Ready]", status ]
+                suspended: [ spec, suspend ]
+                revision: [ status, artifact, revision ]
+                chart_name: [ spec, chart ]
+                chart_version: [ spec, version ]
+          - groupVersionKind:
+              group: source.toolkit.fluxcd.io
+              version: v1
+              kind: OCIRepository
+            metricNamePrefix: gotk
+            metrics:
+            - name: "resource_info"
+              help: "The current state of a Flux OCIRepository resource."
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    name: [ metadata, name ]
+              labelsFromPath:
+                exported_namespace: [ metadata, namespace ]
+                ready: [ status, conditions, "[type=Ready]", status ]
+                suspended: [ spec, suspend ]
+                revision: [ status, artifact, revision ]
+                url: [ spec, url ]
+          - groupVersionKind:
+              group: notification.toolkit.fluxcd.io
+              version: v1beta3
+              kind: Alert
+            metricNamePrefix: gotk
+            metrics:
+            - name: "resource_info"
+              help: "The current state of a Flux Alert resource."
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    name: [ metadata, name ]
+              labelsFromPath:
+                exported_namespace: [ metadata, namespace ]
+                suspended: [ spec, suspend ]
+          - groupVersionKind:
+              group: notification.toolkit.fluxcd.io
+              version: v1beta3
+              kind: Provider
+            metricNamePrefix: gotk
+            metrics:
+            - name: "resource_info"
+              help: "The current state of a Flux Provider resource."
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    name: [ metadata, name ]
+              labelsFromPath:
+                exported_namespace: [ metadata, namespace ]
+                suspended: [ spec, suspend ]
+          - groupVersionKind:
+              group: notification.toolkit.fluxcd.io
+              version: v1
+              kind: Receiver
+            metricNamePrefix: gotk
+            metrics:
+            - name: "resource_info"
+              help: "The current state of a Flux Receiver resource."
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    name: [ metadata, name ]
+              labelsFromPath:
+                exported_namespace: [ metadata, namespace ]
+                ready: [ status, conditions, "[type=Ready]", status ]
+                suspended: [ spec, suspend ]
+                webhook_path: [ status, webhookPath ]
+          - groupVersionKind:
+              group: image.toolkit.fluxcd.io
+              version: v1
+              kind: ImageRepository
+            metricNamePrefix: gotk
+            metrics:
+            - name: "resource_info"
+              help: "The current state of a Flux ImageRepository resource."
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    name: [ metadata, name ]
+              labelsFromPath:
+                exported_namespace: [ metadata, namespace ]
+                ready: [ status, conditions, "[type=Ready]", status ]
+                suspended: [ spec, suspend ]
+                image: [ spec, image ]
+          - groupVersionKind:
+              group: image.toolkit.fluxcd.io
+              version: v1
+              kind: ImagePolicy
+            metricNamePrefix: gotk
+            metrics:
+            - name: "resource_info"
+              help: "The current state of a Flux ImagePolicy resource."
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    name: [ metadata, name ]
+              labelsFromPath:
+                exported_namespace: [ metadata, namespace ]
+                ready: [ status, conditions, "[type=Ready]", status ]
+                suspended: [ spec, suspend ]
+                source_name: [ spec, imageRepositoryRef, name ]
+          - groupVersionKind:
+              group: image.toolkit.fluxcd.io
+              version: v1
+              kind: ImageUpdateAutomation
+            metricNamePrefix: gotk
+            metrics:
+            - name: "resource_info"
+              help: "The current state of a Flux ImageUpdateAutomation resource."
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    name: [ metadata, name ]
+              labelsFromPath:
+                exported_namespace: [ metadata, namespace ]
+                ready: [ status, conditions, "[type=Ready]", status ]
+                suspended: [ spec, suspend ]
+                source_name: [ spec, sourceRef, name ]

--- a/clusters/production/apps/observability/kustomization.yaml
+++ b/clusters/production/apps/observability/kustomization.yaml
@@ -20,13 +20,19 @@ resources:
 - prometheusrule-ceph.yaml
 - prometheusrule-postgres-cnpg.yaml
 - prometheusrule-rabbitmq.yaml
-# Tier-2 custom alerting: Flux GitOps health (controllers are otherwise unscraped — flux-podmonitor.yaml),
-# cert-manager TLS expiry/renewal (scrape enabled via the cert-manager HelmRelease values), and Mosquitto
-# (metrics from the exporter sidecar + PodMonitor in mosquitto-production).
+# Tier-2 custom alerting: Flux GitOps health (controllers are otherwise unscraped — flux-podmonitor.yaml;
+# per-object Ready/suspended via the dedicated Flux kube-state-metrics instance), cert-manager TLS
+# expiry/renewal (scrape enabled via the cert-manager HelmRelease values), and Mosquitto (metrics from
+# the exporter sidecar + PodMonitor in mosquitto-production).
 - flux-podmonitor.yaml
+- kube-state-metrics-flux-helmrelease.yaml
 - prometheusrule-flux.yaml
 - prometheusrule-cert-manager.yaml
 - prometheusrule-mosquitto.yaml
+# External endpoint probing via the off-cluster VPS blackbox-exporter (infra/blackbox-vps/), scraped
+# over the tunnel. Set the prober.url tunnel IP in blackbox-probes.yaml before pushing.
+- blackbox-probes.yaml
+- prometheusrule-blackbox.yaml
 - minio-deployment.yaml
 - minio-buckets-job.yaml
 

--- a/clusters/production/apps/observability/prometheusrule-blackbox.yaml
+++ b/clusters/production/apps/observability/prometheusrule-blackbox.yaml
@@ -1,0 +1,43 @@
+# Alerts on the external blackbox probes (blackbox-probes.yaml, run from the off-cluster VPS).
+# release=obs-kps so the operator ruleSelector picks it up. All series are scoped by
+# probe_origin="vps-external" so these never collide with any future in-cluster probes.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: blackbox-external
+  labels:
+    release: obs-kps
+spec:
+  groups:
+  - name: blackbox-external
+    rules:
+    # The endpoint is unreachable / failing from the internet (TLS error, timeout, or a status the
+    # module rejects — 5xx for core apps). This is the user-facing "the site is down" signal.
+    - alert: ExternalEndpointDown
+      expr: probe_success{probe_origin="vps-external"} == 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: "External probe failing: {{ $labels.instance }}"
+        description: "{{ $labels.instance }} has failed external probing from the VPS for >5m (probe_success=0). Reachability/TLS/HTTP-status problem on the public path — DNS, internet, or the nginx front-end. Check probe_http_status_code and probe_ssl_earliest_cert_expiry for this instance."
+    # The TLS cert SERVED to the internet expires soon. cert-manager rules track the internal renewal
+    # state; this catches the front-end serving a stale/wrong cert. Single warning threshold to avoid
+    # duplicating cert-manager's two-tier paging.
+    - alert: ExternalEndpointCertExpiringSoon
+      expr: (probe_ssl_earliest_cert_expiry{probe_origin="vps-external"} - time()) < 14 * 86400
+      for: 1h
+      labels:
+        severity: warning
+      annotations:
+        summary: "Public TLS cert for {{ $labels.instance }} expires in {{ $value | humanizeDuration }}"
+        description: "The certificate served externally for {{ $labels.instance }} expires in {{ $value | humanizeDuration }}. If cert-manager shows the cert as renewed, the front-end may be serving a stale cert."
+    # Sustained slow responses from the outside — degraded UX even if not fully down.
+    - alert: ExternalEndpointSlow
+      expr: probe_duration_seconds{probe_origin="vps-external"} > 5
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Slow external response: {{ $labels.instance }}"
+        description: "{{ $labels.instance }} has taken >5s to respond to external probes for >10m (currently {{ $value | humanizeDuration }})."

--- a/clusters/production/apps/observability/prometheusrule-flux.yaml
+++ b/clusters/production/apps/observability/prometheusrule-flux.yaml
@@ -1,14 +1,13 @@
-# Flux GitOps health. Metrics come from flux-podmonitor.yaml. release=obs-kps so the operator
-# ruleSelector picks it up. Not covered by kube-prometheus-stack defaults.
+# Flux GitOps health. release=obs-kps so the operator ruleSelector picks it up. Not covered by
+# kube-prometheus-stack defaults. Two metric sources:
+#   - up{job="observability-production/flux"}  → controller liveness (flux-podmonitor.yaml)
+#   - gotk_resource_info                        → per-object Ready/suspended state, emitted by the
+#     dedicated Flux kube-state-metrics instance (kube-state-metrics-flux-helmrelease.yaml). Flux v2.8
+#     controllers do NOT expose gotk_reconcile_condition, hence the KSM CR-state approach.
 #
-# IMPORTANT (Flux v2.8): the controllers do NOT expose gotk_reconcile_condition / gotk_suspend_status
-# (those were removed). Per-object Ready=False detection now requires a kube-state-metrics
-# custom-resource-state config (fluxcd/flux2-monitoring-example) — none is deployed here yet, so these
-# rules use the controllers' built-in controller-runtime metrics instead:
-#   - up                              → controller reachable/alive
-#   - controller_runtime_reconcile_total{result="error"} → reconcile failures, labeled by `controller`
-#     (kustomization, helmrelease, gitrepository, …). Coarser than per-object, but real.
-# Follow-up to add precise per-Kustomization/HelmRelease Ready alerts: deploy the KSM CR-state config.
+# gotk_resource_info is an Info metric (value always 1); state is in labels: `ready`
+# (True/False/Unknown), `suspended` (true when spec.suspend), `name`, `exported_namespace`, and KSM's
+# `customresource_kind`.
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -20,8 +19,7 @@ spec:
   - name: flux-gitops
     rules:
     # A controller's metrics endpoint is unreachable → it's down/crashlooping and nothing it owns
-    # reconciles. job set to <podmonitor-namespace>/<name> by the operator (flux-podmonitor.yaml lives
-    # in observability-production). Per-pod so the alert names which controller.
+    # reconciles. job = <podmonitor-namespace>/<name> (flux-podmonitor.yaml lives in observability-production).
     - alert: FluxControllerDown
       expr: up{job="observability-production/flux"} == 0
       for: 10m
@@ -30,14 +28,23 @@ spec:
       annotations:
         summary: "Flux controller {{ $labels.pod }} is down"
         description: "Flux controller pod {{ $labels.pod }} has been unscrapeable for >10m. While down, the resources it owns are not reconciled."
-    # Sustained reconcile errors from a controller → it is persistently failing to apply something
-    # (bad manifest, failing Helm upgrade, unreachable Git/OCI source, etc.). A transient blip won't
-    # hold rate>0 across the 15m window; a genuinely stuck resource will. `controller` says which kind.
-    - alert: FluxReconcileErrors
-      expr: sum by (controller) (rate(controller_runtime_reconcile_total{job="observability-production/flux",result="error"}[5m])) > 0
+    # A specific Flux object has been not-Ready for >15m (excluding intentionally suspended ones) → that
+    # resource's drift is no longer converging. 15m absorbs normal reconcile-in-progress / Helm upgrades.
+    - alert: FluxResourceNotReady
+      expr: gotk_resource_info{ready="False",suspended!="true"} == 1
       for: 15m
       labels:
         severity: warning
       annotations:
-        summary: "Flux {{ $labels.controller }} controller has persistent reconcile errors"
-        description: "The Flux {{ $labels.controller }} controller has been returning reconcile errors continuously for >15m — GitOps is not converging some resource of this kind. Run `flux get all -A` and check the controller logs."
+        summary: "Flux {{ $labels.customresource_kind }} {{ $labels.exported_namespace }}/{{ $labels.name }} not ready"
+        description: "{{ $labels.customresource_kind }} {{ $labels.exported_namespace }}/{{ $labels.name }} has had Ready=False for >15m — GitOps is not converging it. Check `flux get all -A` and the controller logs."
+    # Reconciliation intentionally paused (`flux suspend`). Usually deliberate, so info (non-paging via the
+    # severity=~info|none → null route) and only after 2h, to catch a suspend someone forgot to lift.
+    - alert: FluxResourceSuspended
+      expr: gotk_resource_info{suspended="true"} == 1
+      for: 2h
+      labels:
+        severity: info
+      annotations:
+        summary: "Flux {{ $labels.customresource_kind }} {{ $labels.exported_namespace }}/{{ $labels.name }} suspended >2h"
+        description: "Reconciliation has been suspended for >2h — Git changes to this resource are not being applied. Run `flux resume {{ $labels.customresource_kind | toLower }} -n {{ $labels.exported_namespace }} {{ $labels.name }}` if unintended."

--- a/infra/blackbox-vps/README.md
+++ b/infra/blackbox-vps/README.md
@@ -1,0 +1,61 @@
+# External blackbox-exporter (VPS)
+
+An off-cluster [blackbox-exporter](https://github.com/prometheus/blackbox_exporter) that probes the
+public `*.wsh.no` endpoints from an **internet vantage point**, so failures on the real public path
+(external DNS → internet → nginx TLS front-end) are caught — the class of user-facing outage that
+in-cluster metrics can't see (e.g. the front-end response-truncation incident).
+
+The cluster Prometheus scrapes this exporter **over the existing tunnel** and turns probe results into
+alerts. The probe targets, modules, and alert rules live in the cluster repo:
+
+- Probes: [`clusters/production/apps/observability/blackbox-probes.yaml`](../../clusters/production/apps/observability/blackbox-probes.yaml)
+- Alerts: [`clusters/production/apps/observability/prometheusrule-blackbox.yaml`](../../clusters/production/apps/observability/prometheusrule-blackbox.yaml)
+
+## Why off-cluster
+
+An in-cluster blackbox would egress and (via DNS/NAT hairpin) re-enter through the internal ingress,
+bypassing the public front-end — so it can't observe what an internet user actually experiences. This
+instance sits outside, on the far side of the front-end.
+
+## Deploy on the VPS
+
+1. Copy this directory (`docker-compose.yml`, `blackbox.yml`) to the VPS.
+2. Set the tunnel IP (the VPS's address on the tunnel the cluster uses), e.g.:
+   ```bash
+   echo "TUNNEL_IP=10.10.0.2" > .env      # <- the VPS's tunnel interface IP
+   docker compose up -d
+   ```
+   The published port binds to `${TUNNEL_IP}:9115` only — reachable from the cluster over the tunnel,
+   **not** from the public internet. Do not bind to `0.0.0.0`.
+3. Confirm it's serving locally and over the tunnel:
+   ```bash
+   curl -s 'http://127.0.0.1:9115/-/healthy'
+   curl -s 'http://127.0.0.1:9115/probe?target=https://clutterstock.wsh.no&module=http_2xx' | grep probe_success
+   ```
+
+## Wire up the cluster side
+
+Put the **same** `TUNNEL_IP` into both Probes' `prober.url` (replace the `10.0.0.0-PLACEHOLDER:9115`
+placeholder) in `blackbox-probes.yaml`, then commit. After Flux reconciles, verify in Prometheus:
+
+```promql
+probe_success{probe_origin="vps-external"}
+probe_ssl_earliest_cert_expiry{probe_origin="vps-external"}
+```
+
+## Firewall / security
+
+- The cluster must reach `TUNNEL_IP:9115` over the tunnel (allow that on the VPS).
+- The exporter must **not** be exposed publicly — binding to the tunnel IP handles this; double-check
+  the VPS firewall does not forward `:9115` from the public interface.
+- blackbox is unauthenticated by design; the tunnel + interface binding is the access control.
+
+## Modules
+
+| Module | Used for | Pass criteria |
+|---|---|---|
+| `http_2xx` | `clutterstock.wsh.no`, `www.wsh.no` | HTTP 2xx + valid TLS |
+| `http_public` | auth-gated / redirecting services (`auth`, `ddns`, `ddnsadmin`, `node-red`, `home-assistant`, `rabbitmq`, `pbs`) | HTTP 200/3xx/401/403 + valid TLS (fails on 5xx/TLS/timeout) |
+
+Re-bucket hosts between the two Probes as you learn each endpoint's real unauthenticated response.
+`*.mgmt.wsh.no` is intentionally **not** probed — it resolves to LAN IPs and is unreachable externally.

--- a/infra/blackbox-vps/blackbox.yml
+++ b/infra/blackbox-vps/blackbox.yml
@@ -1,0 +1,30 @@
+# blackbox-exporter modules for external *.wsh.no probing. Referenced by the Probe CRDs' `module`
+# field (clusters/production/apps/observability/blackbox-probes.yaml).
+modules:
+  # Strict: core public apps must return HTTP 2xx over valid TLS. Used for clutterstock.wsh.no, www.
+  http_2xx:
+    prober: http
+    timeout: 10s
+    http:
+      method: GET
+      valid_http_versions: [ "HTTP/1.1", "HTTP/2.0" ]
+      # empty valid_status_codes = default 2xx only
+      valid_status_codes: []
+      follow_redirects: false
+      fail_if_not_ssl: true
+      preferred_ip_protocol: ip4
+      ip_protocol_fallback: false
+
+  # Lenient: auth-gated / redirecting services where an unauthenticated GET legitimately returns
+  # 200/3xx/401/403. Still fails on 5xx, TLS errors, and timeouts. fail_if_not_ssl keeps it HTTPS-only.
+  http_public:
+    prober: http
+    timeout: 10s
+    http:
+      method: GET
+      valid_http_versions: [ "HTTP/1.1", "HTTP/2.0" ]
+      valid_status_codes: [ 200, 301, 302, 303, 307, 308, 401, 403 ]
+      follow_redirects: false
+      fail_if_not_ssl: true
+      preferred_ip_protocol: ip4
+      ip_protocol_fallback: false

--- a/infra/blackbox-vps/docker-compose.yml
+++ b/infra/blackbox-vps/docker-compose.yml
@@ -1,0 +1,24 @@
+# External blackbox-exporter, run on the off-cluster VPS to probe *.wsh.no from an internet vantage
+# point. The cluster Prometheus scrapes it over the existing tunnel via Probe CRDs
+# (clusters/production/apps/observability/blackbox-probes.yaml).
+#
+# SECURITY: bind the published port to the TUNNEL interface IP only — never 0.0.0.0 — so the exporter
+# is reachable from the cluster over the tunnel but not from the public internet. Set TUNNEL_IP below
+# (or in a .env file) to the VPS's tunnel address; that same IP goes into the Probes' prober.url.
+services:
+  blackbox:
+    image: quay.io/prometheus/blackbox-exporter:v0.28.0
+    container_name: blackbox-exporter
+    restart: unless-stopped
+    command:
+    - --config.file=/etc/blackbox/blackbox.yml
+    volumes:
+    - ./blackbox.yml:/etc/blackbox/blackbox.yml:ro
+    ports:
+    # Only the tunnel interface — e.g. TUNNEL_IP=10.10.0.2 → 10.10.0.2:9115. Do NOT expose publicly.
+    - "${TUNNEL_IP}:9115:9115"
+    read_only: true
+    security_opt:
+    - no-new-privileges:true
+    cap_drop:
+    - ALL


### PR DESCRIPTION
Introduced a new blackbox-exporter setup on an off-cluster VPS to probe public `*.wsh.no` endpoints, capturing user-facing outages that in-cluster metrics may miss. Added configuration files for the blackbox probes, Prometheus rules for alerting on probe failures, and a dedicated kube-state-metrics instance for Flux custom-resource state monitoring. Updated kustomization to include new resources for enhanced observability.

## Description 💬

<!--- Describe your changes in detail -->
