### PR TITLE
chore: update ingress annotations and add siteMonitor URLs

### DIFF
--- a/clusters/production/apps/authelia-production/authelia-helmrelease.yaml
+++ b/clusters/production/apps/authelia-production/authelia-helmrelease.yaml
@@ -79,8 +79,9 @@ spec:
       annotations:
         traefik.ingress.kubernetes.io/router.entrypoints: web
         gethomepage.dev/enabled: "true"
-        gethomepage.dev/group: Management
+        gethomepage.dev/group: Platform
         gethomepage.dev/name: Authelia
+        gethomepage.dev/siteMonitor: https://auth.wsh.no
         gethomepage.dev/icon: mdi-shield-account
         gethomepage.dev/description: SSO / OIDC issuer at auth.wsh.no (Headlamp + Traefik forward auth)
       rulesOverride:

--- a/clusters/production/apps/ddnsadmin/base/ingress.yaml
+++ b/clusters/production/apps/ddnsadmin/base/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Applications
+    gethomepage.dev/group: Apps
     gethomepage.dev/name: ddnsadmin
     gethomepage.dev/icon: mdi-dns-outline
     gethomepage.dev/description: Self-service DNS record administration

--- a/clusters/production/apps/ddnsadmin/production/kustomization.yaml
+++ b/clusters/production/apps/ddnsadmin/production/kustomization.yaml
@@ -45,3 +45,8 @@ patches:
     - op: replace
       path: /spec/rules/0/host
       value: ddns.wsh.no
+    # Homepage health ping. Set here (not in base) because the base host is a REPLACE.ME placeholder
+    # shared with preview overlays; this tile's real host is ddns.wsh.no.
+    - op: add
+      path: /metadata/annotations/gethomepage.dev~1siteMonitor
+      value: https://ddns.wsh.no

--- a/clusters/production/apps/headlamp-production/headlamp-ingress.yaml
+++ b/clusters/production/apps/headlamp-production/headlamp-ingress.yaml
@@ -9,8 +9,9 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
     traefik.ingress.kubernetes.io/router.middlewares: headlamp-production-authelia-forwardauth@kubernetescrd
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Management
+    gethomepage.dev/group: Platform
     gethomepage.dev/name: Headlamp
+    gethomepage.dev/siteMonitor: https://headlamp.mgmt.wsh.no
     gethomepage.dev/icon: mdi-view-dashboard-variant
     gethomepage.dev/description: Kubernetes UI with Flux GitOps plugin
 spec:

--- a/clusters/production/apps/home-assistant-production/home-assistant-ingress.yaml
+++ b/clusters/production/apps/home-assistant-production/home-assistant-ingress.yaml
@@ -9,8 +9,9 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
     traefik.ingress.kubernetes.io/router.middlewares: home-assistant-production-authelia-forwardauth@kubernetescrd
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Applications
+    gethomepage.dev/group: Apps
     gethomepage.dev/name: Home Assistant
+    gethomepage.dev/siteMonitor: https://home-assistant.wsh.no
     gethomepage.dev/icon: mdi-home-assistant
     gethomepage.dev/description: Home automation (network/IP integrations)
 spec:

--- a/clusters/production/apps/homepage/homepage-secrets.md
+++ b/clusters/production/apps/homepage/homepage-secrets.md
@@ -1,0 +1,68 @@
+# Homepage widget credentials
+
+Homepage reads `{{HOMEPAGE_VAR_*}}` placeholders in its config files (e.g. `services.yaml`) from
+environment variables. The `homepage` Deployment pulls them from a Secret named `homepage-secrets`
+via `envFrom` (marked `optional: true`, so the pod starts without it — widgets just stay empty until
+it exists). **Substitution does NOT work in Ingress annotations**, which is why widgets needing a
+credential are defined in `services.yaml`, not on the app's Ingress.
+
+## Proxmox VE + PBS widgets (live now)
+
+These hosts are on the LAN and reachable over the homepage pod's existing egress (no NetworkPolicy
+needed). Create read-only API tokens so the dashboard can't change anything.
+
+### Create read-only API tokens
+
+**Proxmox VE** — Datacenter → Permissions → API Tokens → Add (or `pveum`):
+```bash
+# On a PVE node: create a token for an audit user, role PVEAuditor (read-only), no privilege separation.
+pveum user add homepage@pve
+pveum acl modify / --users homepage@pve --roles PVEAuditor
+pveum user token add homepage@pve homepage --privsep 0
+# -> prints the token value (the "secret"); note the full id homepage@pve!homepage
+```
+
+**Proxmox Backup Server** — Configuration → Access Control → API Token, role `Audit`:
+```bash
+proxmox-backup-manager user create homepage@pbs
+proxmox-backup-manager acl update / Audit --auth-id homepage@pbs
+proxmox-backup-manager user generate-token homepage@pbs homepage   # -> prints the secret
+```
+
+### Create the Secret
+```bash
+kubectl create secret generic homepage-secrets \
+  --namespace platform-production \
+  --from-literal=HOMEPAGE_VAR_PROXMOX_URL='https://<pve-host-or-ip>:8006' \
+  --from-literal=HOMEPAGE_VAR_PROXMOX_USER='homepage@pve!homepage' \
+  --from-literal=HOMEPAGE_VAR_PROXMOX_TOKEN='<pve-token-secret>' \
+  --from-literal=HOMEPAGE_VAR_PBS_URL='https://pbs.wsh.no:8007' \
+  --from-literal=HOMEPAGE_VAR_PBS_USER='homepage@pbs!homepage' \
+  --from-literal=HOMEPAGE_VAR_PBS_TOKEN='<pbs-token-secret>'
+# then: kubectl -n platform-production rollout restart deployment/homepage
+```
+
+> **TLS note:** PVE/PBS usually serve self-signed certs. If the widget shows a TLS error, either give
+> those hosts a cert homepage trusts, or front them with a trusted endpoint. There is no per-widget
+> skip-verify for the proxmox widgets.
+
+## In-cluster widgets (follow-up: Grafana / Alertmanager / RabbitMQ / Home Assistant)
+
+These need two things the LAN widgets don't, so they're a separate pass:
+
+1. **Network**: the homepage pod must reach the service in-cluster. The pod's `0.0.0.0/0` egress does
+   **not** cover cluster-internal pods (Cilium can't match cluster identities by CIDR — same limit as
+   the mosquitto/cert-manager scrape work), so each needs a CiliumNetworkPolicy egress from homepage
+   to the target, plus an ingress allowance on the target if it has a default-deny policy.
+2. **Config**: the credential must live in `services.yaml` (not the annotation), so each tile is
+   converted from auto-discovered to a static `services.yaml` entry with `gethomepage.dev/enabled:
+   "false"` on its Ingress to avoid a duplicate tile.
+
+Planned `HOMEPAGE_VAR_*` for that pass (add to the same Secret when wired):
+
+| Widget | Type | In-cluster URL | Auth |
+|---|---|---|---|
+| Alertmanager | `alertmanager` | `http://obs-kps-kube-prometheus-st-alertmanager.observability-production:9093` | none |
+| Grafana | `grafana` | `http://obs-kps-grafana.observability-production:80` | `HOMEPAGE_VAR_GRAFANA_USER/PASSWORD` (local admin; basic_auth API) |
+| RabbitMQ | `rabbitmq` | `http://rabbitmq.rabbitmq-production:15672` | `HOMEPAGE_VAR_RABBITMQ_USER/PASSWORD` (mgmt user) |
+| Home Assistant | `homeassistant` | `http://home-assistant.home-assistant-production:8123` | `HOMEPAGE_VAR_HASS_TOKEN` (long-lived token) |

--- a/clusters/production/apps/homepage/homepage.yaml
+++ b/clusters/production/apps/homepage/homepage.yaml
@@ -33,11 +33,66 @@ data:
   settings.yaml: |
     title: Production Management
     favicon: https://gethomepage.dev/favicon.ico
+    headerStyle: clean
+    # Group order + per-group layout. Groups are populated from the ingress gethomepage.dev/group
+    # annotations (Apps/Observability/Data/Platform) plus the static Infrastructure tiles in
+    # services.yaml. Any group not listed here still renders, appended after these.
+    layout:
+      Apps:
+        style: row
+        columns: 4
+      Observability:
+        style: row
+        columns: 4
+      Data:
+        style: row
+        columns: 4
+      Platform:
+        style: row
+        columns: 4
+      Infrastructure:
+        style: row
+        columns: 4
   custom.css: ""
   custom.js: ""
   bookmarks.yaml: ""
-  services.yaml: ""
+  # Static tiles that have no in-cluster Ingress to auto-discover from. The Proxmox VE / PBS hosts are
+  # on the LAN, reachable over the homepage pod's existing egress (no netpol). Secrets are injected as
+  # {{HOMEPAGE_VAR_*}} from the `homepage-secrets` Secret (envFrom in the Deployment) — substitution
+  # works in this file but NOT in ingress annotations. See homepage-secrets.md.
+  # The proxmox widget `password` is the API-token SECRET; `username` is user@realm!tokenid.
+  services.yaml: |
+    - Infrastructure:
+        - Proxmox VE:
+            icon: proxmox
+            href: "{{HOMEPAGE_VAR_PROXMOX_URL}}"
+            description: Virtualization + Ceph cluster
+            siteMonitor: "{{HOMEPAGE_VAR_PROXMOX_URL}}"
+            widget:
+              type: proxmox
+              url: "{{HOMEPAGE_VAR_PROXMOX_URL}}"
+              username: "{{HOMEPAGE_VAR_PROXMOX_USER}}"
+              password: "{{HOMEPAGE_VAR_PROXMOX_TOKEN}}"
+        - Proxmox Backup Server:
+            icon: proxmox
+            href: "{{HOMEPAGE_VAR_PBS_URL}}"
+            description: Backup datastores
+            siteMonitor: "{{HOMEPAGE_VAR_PBS_URL}}"
+            widget:
+              type: proxmoxbackupserver
+              url: "{{HOMEPAGE_VAR_PBS_URL}}"
+              username: "{{HOMEPAGE_VAR_PBS_USER}}"
+              password: "{{HOMEPAGE_VAR_PBS_TOKEN}}"
   widgets.yaml: |
+    - greeting:
+        text_size: xl
+        text: Production
+    - datetime:
+        text_size: xl
+        format:
+          dateStyle: short
+          timeStyle: short
+          hourCycle: h23
     - kubernetes:
         cluster:
           show: true
@@ -54,12 +109,9 @@ data:
         provider: duckduckgo
         target: _blank
   docker.yaml: ""
-  proxmox.yaml: |
-    ---
-    # pve:
-    # url: https://proxmox.host.or.ip:8006
-    # token: username@pam!Token ID
-    # secret: secret
+  # Legacy file kept only to satisfy the Deployment subPath mount; the Proxmox widget is configured
+  # inline in services.yaml (Phase B), not here.
+  proxmox.yaml: ""
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -163,6 +215,13 @@ spec:
               fieldPath: status.podIP
         - name: HOMEPAGE_ALLOWED_HOSTS
           value: "$(MY_POD_IP):3000,mgmt.wsh.no"
+        # HOMEPAGE_VAR_* values for services.yaml widget credentials (Proxmox/PBS). Optional so the pod
+        # still starts before the Secret exists; widgets just stay empty until it's created. See
+        # homepage-secrets.md.
+        envFrom:
+        - secretRef:
+            name: homepage-secrets
+            optional: true
         ports:
         - name: http
           containerPort: 3000

--- a/clusters/production/apps/hubble-ui-ingress.yaml
+++ b/clusters/production/apps/hubble-ui-ingress.yaml
@@ -8,8 +8,9 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: web
     traefik.ingress.kubernetes.io/router.middlewares: headlamp-production-authelia-forwardauth@kubernetescrd
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Management
+    gethomepage.dev/group: Observability
     gethomepage.dev/name: Hubble
+    gethomepage.dev/siteMonitor: https://hubble.mgmt.wsh.no
     gethomepage.dev/icon: mdi-chart-timeline-variant
     gethomepage.dev/description: Cilium Hubble service map & flows
 spec:

--- a/clusters/production/apps/ingress.yaml
+++ b/clusters/production/apps/ingress.yaml
@@ -6,8 +6,9 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Applications
+    gethomepage.dev/group: Apps
     gethomepage.dev/name: Clutterstock
+    gethomepage.dev/siteMonitor: https://clutterstock.wsh.no
     gethomepage.dev/icon: mdi-image-multiple-outline
     gethomepage.dev/description: Clutterstock web app (API under /api/; Swagger under /swagger)
     # Ingress name ≠ single Deployment; both pods back this host (see gethomepage kubernetes.md)
@@ -47,8 +48,9 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Applications
+    gethomepage.dev/group: Apps
     gethomepage.dev/name: Clutterstock (test)
+    gethomepage.dev/siteMonitor: https://clutterstock.test.wsh.no
     gethomepage.dev/icon: mdi-image-multiple-outline
     gethomepage.dev/description: Playwright / release checks — isolated SQLite + shared-test Redis; not production data
     gethomepage.dev/pod-selector: app in (clutterstock-frontend, clutterstock-api)
@@ -90,8 +92,9 @@ metadata:
     # pin it to the www form explicitly.
     gethomepage.dev/href: "https://www.wsh.no/"
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Applications
+    gethomepage.dev/group: Apps
     gethomepage.dev/name: wsh.no
+    gethomepage.dev/siteMonitor: https://www.wsh.no
     gethomepage.dev/icon: mdi-web
     gethomepage.dev/description: Personal homepage (root domain)
 spec:
@@ -127,8 +130,9 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Management
+    gethomepage.dev/group: Platform
     gethomepage.dev/name: Homepage
+    gethomepage.dev/siteMonitor: https://mgmt.wsh.no
     gethomepage.dev/icon: homepage
     gethomepage.dev/description: Service dashboard
 spec:

--- a/clusters/production/apps/mosquitto-production/mqttui-ingress.yaml
+++ b/clusters/production/apps/mosquitto-production/mqttui-ingress.yaml
@@ -8,8 +8,9 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
     traefik.ingress.kubernetes.io/router.middlewares: mosquitto-production-authelia-forwardauth@kubernetescrd
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Management
+    gethomepage.dev/group: Platform
     gethomepage.dev/name: MQTT UI
+    gethomepage.dev/siteMonitor: https://mqtt.mgmt.wsh.no
     gethomepage.dev/icon: mdi-transit-connection-variant
     gethomepage.dev/description: Mosquitto broker inspector
 spec:

--- a/clusters/production/apps/node-red-production/node-red-ingress.yaml
+++ b/clusters/production/apps/node-red-production/node-red-ingress.yaml
@@ -9,8 +9,9 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
     traefik.ingress.kubernetes.io/router.middlewares: node-red-production-authelia-forwardauth@kubernetescrd
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Applications
+    gethomepage.dev/group: Apps
     gethomepage.dev/name: Node-RED
+    gethomepage.dev/siteMonitor: https://node-red.wsh.no
     gethomepage.dev/icon: node-red
     gethomepage.dev/description: Flow-based automation editor
 spec:

--- a/clusters/production/apps/observability/observability-ingress.yaml
+++ b/clusters/production/apps/observability/observability-ingress.yaml
@@ -6,8 +6,9 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Management
+    gethomepage.dev/group: Observability
     gethomepage.dev/name: Grafana
+    gethomepage.dev/siteMonitor: https://grafana.mgmt.wsh.no
     gethomepage.dev/icon: grafana
     gethomepage.dev/description: Observability dashboards
 spec:
@@ -59,8 +60,9 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: web
     traefik.ingress.kubernetes.io/router.middlewares: observability-production-otel-cors@kubernetescrd
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Management
+    gethomepage.dev/group: Observability
     gethomepage.dev/name: OpenTelemetry Collector
+    gethomepage.dev/siteMonitor: https://otel.mgmt.wsh.no
     gethomepage.dev/icon: opentelemetry
     gethomepage.dev/description: OTLP HTTP endpoint
     # Ingress name is not a pod label; match the OTel Helm release (same as test cluster).
@@ -149,8 +151,9 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: web
     traefik.ingress.kubernetes.io/router.middlewares: headlamp-production-authelia-forwardauth@kubernetescrd
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Management
+    gethomepage.dev/group: Observability
     gethomepage.dev/name: Alertmanager
+    gethomepage.dev/siteMonitor: https://alertmanager.mgmt.wsh.no
     gethomepage.dev/icon: mdi-bell-alert
     gethomepage.dev/description: Prometheus alerts
 spec:

--- a/clusters/production/apps/policy-reporter-production/policy-reporter-ingress.yaml
+++ b/clusters/production/apps/policy-reporter-production/policy-reporter-ingress.yaml
@@ -7,8 +7,9 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: web
     traefik.ingress.kubernetes.io/router.middlewares: headlamp-production-authelia-forwardauth@kubernetescrd
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Management
+    gethomepage.dev/group: Observability
     gethomepage.dev/name: Policy Reporter
+    gethomepage.dev/siteMonitor: https://policy-reporter.mgmt.wsh.no
     gethomepage.dev/icon: mdi-clipboard-text-search
     gethomepage.dev/description: Kyverno policy reports dashboard
 spec:

--- a/clusters/production/apps/postgres-production/adminer-ingress.yaml
+++ b/clusters/production/apps/postgres-production/adminer-ingress.yaml
@@ -6,8 +6,9 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Management
+    gethomepage.dev/group: Data
     gethomepage.dev/name: Adminer (Postgres production)
+    gethomepage.dev/siteMonitor: https://adminer-pg-prod.mgmt.wsh.no
     gethomepage.dev/icon: mdi-database-outline
     gethomepage.dev/description: Adminer for CNPG postgres-production (OIDC via oauth2-proxy + Authelia); default postgres-prod-rw
     gethomepage.dev/weight: "11"

--- a/clusters/production/apps/postgres-test/adminer-ingress.yaml
+++ b/clusters/production/apps/postgres-test/adminer-ingress.yaml
@@ -8,8 +8,9 @@ metadata:
     # and HTTPS to Traefik (`websecure`). Without `websecure`, https://… to Traefik :443 returns 404.
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Management
+    gethomepage.dev/group: Data
     gethomepage.dev/name: Adminer (Postgres test tier)
+    gethomepage.dev/siteMonitor: https://adminer-pg-test.mgmt.wsh.no
     gethomepage.dev/icon: mdi-database-outline
     gethomepage.dev/description: Adminer for CNPG postgres-test (OIDC via oauth2-proxy + Authelia); default testdb-rw
     gethomepage.dev/weight: "12"

--- a/clusters/production/apps/rabbitmq-production/rabbitmq-management-ingress.yaml
+++ b/clusters/production/apps/rabbitmq-production/rabbitmq-management-ingress.yaml
@@ -7,8 +7,9 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Management
+    gethomepage.dev/group: Data
     gethomepage.dev/name: RabbitMQ
+    gethomepage.dev/siteMonitor: https://rabbitmq.mgmt.wsh.no
     gethomepage.dev/icon: mdi-rabbit
     gethomepage.dev/description: HA broker management — rabbitmq-production cluster
     gethomepage.dev/weight: "8"

--- a/clusters/production/apps/shared/production/redisinsight-ingress.yaml
+++ b/clusters/production/apps/shared/production/redisinsight-ingress.yaml
@@ -7,8 +7,9 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: web
     traefik.ingress.kubernetes.io/router.middlewares: headlamp-production-authelia-forwardauth@kubernetescrd
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Management
+    gethomepage.dev/group: Data
     gethomepage.dev/name: RedisInsight (production Valkey)
+    gethomepage.dev/siteMonitor: https://redis-prod.mgmt.wsh.no
     gethomepage.dev/icon: redis
     gethomepage.dev/description: shared-production Valkey (Redis protocol) — preconnected to redis.shared-production.svc.cluster.local
     gethomepage.dev/weight: "5"

--- a/clusters/production/apps/shared/test/redisinsight-ingress.yaml
+++ b/clusters/production/apps/shared/test/redisinsight-ingress.yaml
@@ -7,8 +7,9 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: web
     traefik.ingress.kubernetes.io/router.middlewares: headlamp-production-authelia-forwardauth@kubernetescrd
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Management
+    gethomepage.dev/group: Data
     gethomepage.dev/name: RedisInsight (test Valkey)
+    gethomepage.dev/siteMonitor: https://redis-test.mgmt.wsh.no
     gethomepage.dev/icon: redis
     gethomepage.dev/description: shared-test Valkey (Redis protocol) — preconnected to redis.shared-test.svc.cluster.local
     gethomepage.dev/weight: "10"

--- a/clusters/production/apps/test-test/test-ingress.yaml
+++ b/clusters/production/apps/test-test/test-ingress.yaml
@@ -6,8 +6,9 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Applications
+    gethomepage.dev/group: Apps
     gethomepage.dev/name: Test (repo sample)
+    gethomepage.dev/siteMonitor: https://test.test.wsh.no
     gethomepage.dev/icon: mdi-application-outline
     gethomepage.dev/description: Sample test app — API under /api/; Swagger under /swagger
     gethomepage.dev/pod-selector: app in (test-frontend, test-api)


### PR DESCRIPTION
Modified ingress configurations across multiple applications to update the `gethomepage.dev/group` annotations for better categorization. Added `gethomepage.dev/siteMonitor` URLs for enhanced monitoring capabilities. This change improves the organization of services and facilitates better observability.

## Description 💬

<!--- Describe your changes in detail -->
