### PR TITLE
feat: add CiliumNetworkPolicies for homepage access to Home Assistant…

### DIFF
--- a/clusters/production/apps/home-assistant-production/cilium-homepage-to-home-assistant.yaml
+++ b/clusters/production/apps/home-assistant-production/cilium-homepage-to-home-assistant.yaml
@@ -1,0 +1,21 @@
+# Allow the homepage dashboard (platform-production) to reach Home Assistant's HTTP API for its widget
+# (entity/automation counts). Mirrors allow-node-red-to-home-assistant-http. Egress side is granted by
+# allow-homepage-to-widget-targets in platform-production.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-homepage-to-home-assistant-http
+  namespace: home-assistant-production
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: home-assistant
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        app.kubernetes.io/name: homepage
+        k8s:io.kubernetes.pod.namespace: platform-production
+    toPorts:
+    - ports:
+      - port: "8123"
+        protocol: TCP

--- a/clusters/production/apps/home-assistant-production/home-assistant-ingress.yaml
+++ b/clusters/production/apps/home-assistant-production/home-assistant-ingress.yaml
@@ -8,12 +8,10 @@ metadata:
     gethomepage.dev/href: "https://home-assistant.wsh.no/"
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
     traefik.ingress.kubernetes.io/router.middlewares: home-assistant-production-authelia-forwardauth@kubernetescrd
-    gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Apps
+    # Auto-discovery disabled — Home Assistant is a static tile in homepage services.yaml (the widget
+    # needs a long-lived token, which can't live in annotations). See homepage-secrets.md.
+    gethomepage.dev/enabled: "false"
     gethomepage.dev/name: Home Assistant
-    gethomepage.dev/siteMonitor: https://home-assistant.wsh.no
-    gethomepage.dev/icon: mdi-home-assistant
-    gethomepage.dev/description: Home automation (network/IP integrations)
 spec:
   rules:
   - host: home-assistant.wsh.no

--- a/clusters/production/apps/home-assistant-production/kustomization.yaml
+++ b/clusters/production/apps/home-assistant-production/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - home-assistant-ingress.yaml
 - cilium-cluster-nodes-to-http.yaml
 - cilium-node-red-to-home-assistant.yaml
+- cilium-homepage-to-home-assistant.yaml
 - kyverno-rbac-generate-pbs-encryption-keyfile.yaml
 - home-assistant-pbs-backup-cronjob.yaml
 # Restore is home-assistant-pbs-restore-job.yaml — apply manually so Flux does not keep a failed/duplicate restore Job.

--- a/clusters/production/apps/homepage/homepage-secrets.md
+++ b/clusters/production/apps/homepage/homepage-secrets.md
@@ -46,7 +46,12 @@ kubectl create secret generic homepage-secrets \
   --from-literal=HOMEPAGE_VAR_PBS_OSL_TOKEN='<pbs-osl-token-secret>' \
   --from-literal=HOMEPAGE_VAR_PBS_KS_URL='https://pbs.ks.wsh.no:8007' \
   --from-literal=HOMEPAGE_VAR_PBS_KS_USER='homepage@pbs!homepage' \
-  --from-literal=HOMEPAGE_VAR_PBS_KS_TOKEN='<pbs-ks-token-secret>'
+  --from-literal=HOMEPAGE_VAR_PBS_KS_TOKEN='<pbs-ks-token-secret>' \
+  --from-literal=HOMEPAGE_VAR_GRAFANA_USER='homepage' \
+  --from-literal=HOMEPAGE_VAR_GRAFANA_PASSWORD='<grafana-viewer-password>' \
+  --from-literal=HOMEPAGE_VAR_RABBITMQ_USER='homepage' \
+  --from-literal=HOMEPAGE_VAR_RABBITMQ_PASSWORD='<rabbitmq-monitoring-password>' \
+  --from-literal=HOMEPAGE_VAR_HASS_TOKEN='<home-assistant-long-lived-token>'
 # then: kubectl -n platform-production rollout restart deployment/homepage
 ```
 
@@ -54,23 +59,35 @@ kubectl create secret generic homepage-secrets \
 > those hosts a cert homepage trusts, or front them with a trusted endpoint. There is no per-widget
 > skip-verify for the proxmox widgets.
 
-## In-cluster widgets (follow-up: Grafana / Alertmanager / RabbitMQ / Home Assistant)
+## In-cluster widgets (Grafana / Alertmanager / RabbitMQ / Home Assistant)
 
-These need two things the LAN widgets don't, so they're a separate pass:
+These are wired (static tiles in `services.yaml`; their Ingresses set `gethomepage.dev/enabled:"false"`
+to avoid duplicates). Reachability: the homepage pod's `0.0.0.0/0` egress does **not** cover
+cluster-internal pods (Cilium can't match cluster identities by CIDR — same limit as the
+mosquitto/cert-manager scrape work), so `homepage/networkpolicies.yaml` adds an egress CNP to each
+target; RabbitMQ + Home Assistant also get `allow-homepage-*` ingress CNPs in their namespaces
+(Grafana/Alertmanager are unrestricted in observability-production). **Alertmanager** needs no
+credential — its widget is set via Ingress annotations and isn't in the Secret.
 
-1. **Network**: the homepage pod must reach the service in-cluster. The pod's `0.0.0.0/0` egress does
-   **not** cover cluster-internal pods (Cilium can't match cluster identities by CIDR — same limit as
-   the mosquitto/cert-manager scrape work), so each needs a CiliumNetworkPolicy egress from homepage
-   to the target, plus an ingress allowance on the target if it has a default-deny policy.
-2. **Config**: the credential must live in `services.yaml` (not the annotation), so each tile is
-   converted from auto-discovered to a static `services.yaml` entry with `gethomepage.dev/enabled:
-   "false"` on its Ingress to avoid a duplicate tile.
+| Widget | In-cluster URL | Credential vars |
+|---|---|---|
+| Alertmanager | `…alertmanager.observability-production:9093` | none |
+| Grafana | `obs-kps-grafana.observability-production:80` | `HOMEPAGE_VAR_GRAFANA_USER` / `…_PASSWORD` |
+| RabbitMQ | `rabbitmq.rabbitmq-production:15672` | `HOMEPAGE_VAR_RABBITMQ_USER` / `…_PASSWORD` |
+| Home Assistant | `home-assistant.home-assistant-production:8123` | `HOMEPAGE_VAR_HASS_TOKEN` |
 
-Planned `HOMEPAGE_VAR_*` for that pass (add to the same Secret when wired):
+### Creating the credentials (read-only where possible)
 
-| Widget | Type | In-cluster URL | Auth |
-|---|---|---|---|
-| Alertmanager | `alertmanager` | `http://obs-kps-kube-prometheus-st-alertmanager.observability-production:9093` | none |
-| Grafana | `grafana` | `http://obs-kps-grafana.observability-production:80` | `HOMEPAGE_VAR_GRAFANA_USER/PASSWORD` (local admin; basic_auth API) |
-| RabbitMQ | `rabbitmq` | `http://rabbitmq.rabbitmq-production:15672` | `HOMEPAGE_VAR_RABBITMQ_USER/PASSWORD` (mgmt user) |
-| Home Assistant | `homeassistant` | `http://home-assistant.home-assistant-production:8123` | `HOMEPAGE_VAR_HASS_TOKEN` (long-lived token) |
+- **Grafana** — basic-auth works on the API even with the login form disabled (`auth.basic` is on by
+  default). Create a Viewer user named `homepage` (Administration → Users, or via the admin API) and use
+  its password. Avoid using the admin account.
+- **RabbitMQ** — create a `monitoring`-tag user (read-only management):
+  ```bash
+  kubectl -n rabbitmq-production exec sts/rabbitmq-server -c rabbitmq -- \
+    rabbitmqctl add_user homepage '<password>'
+  kubectl -n rabbitmq-production exec sts/rabbitmq-server -c rabbitmq -- \
+    rabbitmqctl set_user_tags homepage monitoring
+  kubectl -n rabbitmq-production exec sts/rabbitmq-server -c rabbitmq -- \
+    rabbitmqctl set_permissions -p / homepage '' '' '.*'   # read-only
+  ```
+- **Home Assistant** — Profile → Security → Long-lived access tokens → Create Token.

--- a/clusters/production/apps/homepage/homepage.yaml
+++ b/clusters/production/apps/homepage/homepage.yaml
@@ -62,6 +62,43 @@ data:
   # works in this file but NOT in ingress annotations. See homepage-secrets.md.
   # The proxmox widget `password` is the API-token SECRET; `username` is user@realm!tokenid.
   services.yaml: |
+    # In-cluster widgets: defined statically (not via Ingress annotations) because their credentials
+    # come from {{HOMEPAGE_VAR_*}}, which only substitutes in this file. Auto-discovery is disabled on
+    # the matching Ingresses (gethomepage.dev/enabled:"false") to avoid duplicate tiles. Reachability
+    # is granted by the allow-homepage-to-widget-targets CiliumNetworkPolicy. Alertmanager stays
+    # auto-discovered (no credential) with its widget set via annotations.
+    - Apps:
+        - Home Assistant:
+            icon: mdi-home-assistant
+            href: https://home-assistant.wsh.no/
+            description: Home automation
+            siteMonitor: https://home-assistant.wsh.no
+            widget:
+              type: homeassistant
+              url: http://home-assistant.home-assistant-production.svc.cluster.local:8123
+              key: "{{HOMEPAGE_VAR_HASS_TOKEN}}"
+    - Observability:
+        - Grafana:
+            icon: grafana
+            href: https://grafana.mgmt.wsh.no/
+            description: Observability dashboards
+            siteMonitor: https://grafana.mgmt.wsh.no
+            widget:
+              type: grafana
+              url: http://obs-kps-grafana.observability-production.svc.cluster.local:80
+              username: "{{HOMEPAGE_VAR_GRAFANA_USER}}"
+              password: "{{HOMEPAGE_VAR_GRAFANA_PASSWORD}}"
+    - Data:
+        - RabbitMQ:
+            icon: mdi-rabbit
+            href: https://rabbitmq.mgmt.wsh.no/
+            description: HA broker management
+            siteMonitor: https://rabbitmq.mgmt.wsh.no
+            widget:
+              type: rabbitmq
+              url: http://rabbitmq.rabbitmq-production.svc.cluster.local:15672
+              username: "{{HOMEPAGE_VAR_RABBITMQ_USER}}"
+              password: "{{HOMEPAGE_VAR_RABBITMQ_PASSWORD}}"
     - Infrastructure:
         - Proxmox VE:
             icon: proxmox

--- a/clusters/production/apps/homepage/networkpolicies.yaml
+++ b/clusters/production/apps/homepage/networkpolicies.yaml
@@ -51,3 +51,51 @@ spec:
   egress:
   - toEntities:
     - kube-apiserver
+---
+# Egress for the in-cluster service widgets (homepage.yaml services.yaml). The k8s NP's 0.0.0.0/0 egress
+# does NOT cover cluster-internal pods (Cilium can't match cluster identities by CIDR), so each target
+# needs an explicit toEndpoints rule. Targets also allow homepage on their ingress side (Grafana/
+# Alertmanager are unrestricted in observability-production; RabbitMQ + Home Assistant get matching
+# allow-homepage-* CNPs in their namespaces).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-homepage-to-widget-targets
+  namespace: platform-production
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: homepage
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: observability-production
+        app.kubernetes.io/name: grafana
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+  - toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: observability-production
+        app.kubernetes.io/name: alertmanager
+    toPorts:
+    - ports:
+      - port: "9093"
+        protocol: TCP
+  - toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: rabbitmq-production
+        app.kubernetes.io/name: rabbitmq
+    toPorts:
+    - ports:
+      - port: "15672"
+        protocol: TCP
+  - toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: home-assistant-production
+        app.kubernetes.io/name: home-assistant
+    toPorts:
+    - ports:
+      - port: "8123"
+        protocol: TCP

--- a/clusters/production/apps/observability/observability-ingress.yaml
+++ b/clusters/production/apps/observability/observability-ingress.yaml
@@ -5,12 +5,10 @@ metadata:
   namespace: observability-production
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web
-    gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Observability
+    # Auto-discovery disabled — Grafana is a static tile in homepage services.yaml (the widget needs
+    # credentials, which can't live in annotations). See homepage-secrets.md.
+    gethomepage.dev/enabled: "false"
     gethomepage.dev/name: Grafana
-    gethomepage.dev/siteMonitor: https://grafana.mgmt.wsh.no
-    gethomepage.dev/icon: grafana
-    gethomepage.dev/description: Observability dashboards
 spec:
   rules:
   - host: grafana.mgmt.wsh.no
@@ -156,6 +154,10 @@ metadata:
     gethomepage.dev/siteMonitor: https://alertmanager.mgmt.wsh.no
     gethomepage.dev/icon: mdi-bell-alert
     gethomepage.dev/description: Prometheus alerts
+    # Live firing-alert counts. No credential (in-cluster AM has no auth) so the widget can live on the
+    # annotation; URL is the in-cluster service. Reachability via allow-homepage-to-widget-targets.
+    gethomepage.dev/widget.type: alertmanager
+    gethomepage.dev/widget.url: http://obs-kps-kube-prometheus-st-alertmanager.observability-production.svc.cluster.local:9093
 spec:
   rules:
   - host: alertmanager.mgmt.wsh.no

--- a/clusters/production/apps/rabbitmq-production/cilium-homepage-to-rabbitmq-management.yaml
+++ b/clusters/production/apps/rabbitmq-production/cilium-homepage-to-rabbitmq-management.yaml
@@ -1,0 +1,21 @@
+# Allow the homepage dashboard (platform-production) to reach the RabbitMQ management API (15672) for
+# its widget (queue/message stats). The rabbitmq pods are default-deny ingress (NetworkPolicy rabbitmq);
+# this CNP adds the homepage allowance (union). Egress side is granted by allow-homepage-to-widget-targets.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-homepage-to-rabbitmq-management
+  namespace: rabbitmq-production
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: rabbitmq
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        app.kubernetes.io/name: homepage
+        k8s:io.kubernetes.pod.namespace: platform-production
+    toPorts:
+    - ports:
+      - port: "15672"
+        protocol: TCP

--- a/clusters/production/apps/rabbitmq-production/kustomization.yaml
+++ b/clusters/production/apps/rabbitmq-production/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
 - topology-permission-clutterstock-prod.yaml
 - networkpolicy-rabbitmq.yaml
 - cilium-cluster-nodes-to-rabbitmq-management.yaml
+- cilium-homepage-to-rabbitmq-management.yaml
 - rabbitmq-management-ingress.yaml
 # Patches: label rabbitmq-system so trust-manager's wsh-internal-ca Bundle renders the ConfigMap
 # there, then mount it into the topology operator Pod so Go's x509 trust includes our self-signed

--- a/clusters/production/apps/rabbitmq-production/rabbitmq-management-ingress.yaml
+++ b/clusters/production/apps/rabbitmq-production/rabbitmq-management-ingress.yaml
@@ -6,14 +6,10 @@ metadata:
   namespace: rabbitmq-production
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web
-    gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Data
+    # Auto-discovery disabled — RabbitMQ is a static tile in homepage services.yaml (the widget needs
+    # management-API credentials, which can't live in annotations). See homepage-secrets.md.
+    gethomepage.dev/enabled: "false"
     gethomepage.dev/name: RabbitMQ
-    gethomepage.dev/siteMonitor: https://rabbitmq.mgmt.wsh.no
-    gethomepage.dev/icon: mdi-rabbit
-    gethomepage.dev/description: HA broker management — rabbitmq-production cluster
-    gethomepage.dev/weight: "8"
-    gethomepage.dev/pod-selector: app.kubernetes.io/name=rabbitmq
 spec:
   rules:
   - host: rabbitmq.mgmt.wsh.no


### PR DESCRIPTION
… and RabbitMQ

Introduced new CiliumNetworkPolicies to allow the homepage dashboard in platform-production to access the Home Assistant HTTP API and RabbitMQ management API. Updated ingress configurations to disable auto-discovery for these services, ensuring proper credential management and preventing duplicate tiles in the homepage. Enhanced the homepage-secrets documentation to include new credential variables for RabbitMQ and Home Assistant.

## Description 💬

<!--- Describe your changes in detail -->
