### PR TITLE
chore(kyverno): replace deprecated predicateType with type in supply-chain policies

### DIFF
--- a/bases/kyverno-supply-chain/clusterpolicy-cosign-vuln-attestation.yaml
+++ b/bases/kyverno-supply-chain/clusterpolicy-cosign-vuln-attestation.yaml
@@ -59,7 +59,8 @@ spec:
       verifyDigest: false
       useCache: true
       attestations:
-      - predicateType: https://cosign.sigstore.dev/attestation/vuln/v1
+      # `type` (not the deprecated `predicateType`) — the in-toto predicate type.
+      - type: https://cosign.sigstore.dev/attestation/vuln/v1
         attestors:
         - entries:
           - keyless:

--- a/bases/kyverno-supply-chain/clusterpolicy-cyclonedx-sbom.yaml
+++ b/bases/kyverno-supply-chain/clusterpolicy-cyclonedx-sbom.yaml
@@ -60,7 +60,8 @@ spec:
       verifyDigest: false
       useCache: true
       attestations:
-      - predicateType: https://cyclonedx.org/bom
+      # `type` (not the deprecated `predicateType`) — the in-toto predicate type.
+      - type: https://cyclonedx.org/bom
         attestors:
         - entries:
           - keyless:

--- a/bases/kyverno-supply-chain/clusterpolicy-github-slsa-provenance.yaml
+++ b/bases/kyverno-supply-chain/clusterpolicy-github-slsa-provenance.yaml
@@ -92,7 +92,9 @@ spec:
       useCache: true
       type: SigstoreBundle
       attestations:
-      - predicateType: https://slsa.dev/provenance/v1
+      # `type` (not the deprecated `predicateType`) — this is the in-toto predicate type of the
+      # attestation. Distinct from `type: SigstoreBundle` above, which is the signature format.
+      - type: https://slsa.dev/provenance/v1
         attestors:
         - entries:
           - keyless:
@@ -120,7 +122,9 @@ spec:
       useCache: true
       type: SigstoreBundle
       attestations:
-      - predicateType: https://slsa.dev/provenance/v1
+      # `type` (not the deprecated `predicateType`) — this is the in-toto predicate type of the
+      # attestation. Distinct from `type: SigstoreBundle` above, which is the signature format.
+      - type: https://slsa.dev/provenance/v1
         attestors:
         - entries:
           - keyless:
@@ -155,7 +159,9 @@ spec:
       useCache: true
       type: SigstoreBundle
       attestations:
-      - predicateType: https://slsa.dev/provenance/v1
+      # `type` (not the deprecated `predicateType`) — this is the in-toto predicate type of the
+      # attestation. Distinct from `type: SigstoreBundle` above, which is the signature format.
+      - type: https://slsa.dev/provenance/v1
         attestors:
         - entries:
           - keyless:


### PR DESCRIPTION
## What

Renames `attestations[].predicateType` → `attestations[].type` in the three `bases/kyverno-supply-chain` ClusterPolicies (5 occurrences).

Kyverno logs a deprecation warning on every apply:

```
Warning: predicateType has been deprecated use 'type: https://slsa.dev/provenance/v1'
instead of 'predicateType: https://slsa.dev/provenance/v1'
```

The ClusterPolicy CRD marks the field *"Deprecated in favour of 'Type', to be removed soon"*, so this would break on a future Kyverno major.

## Note on the two `type` fields

`attestations[].type` (the in-toto predicate type) is a **different field** from `verifyImages[].type` (the signature format, `SigstoreBundle`). Only the former is renamed — the `type: SigstoreBundle` lines are deliberately untouched.

## Verification

Applied to the production cluster and probed each verification block:

| Case | Expected | Result |
|---|---|---|
| `ghcr.io/hwinther/clutterstock/frontend:0.27.0` | admit + digest-pin | admitted, mutated to `@sha256:f629ab56…` |
| `ghcr.io/wshno/wshno/web:0.10.0` | admit + digest-pin | admitted, mutated to `@sha256:820366e2…` |
| `ghcr.io/hwinther/clutterstock/frontend:9.9.9-unsigned` | deny | denied, `verifiedCount: 0, requiredCount: 1` |

The `wshno` case matters because it exercises the separate `externalParameters.workflow.repository` condition — admitting it proves the SLSA predicate is still being matched and its conditions evaluated under the new field name. The deprecation warning no longer appears on apply.

Follow-up to `b420c34` (the `verifyDigest: false` fix); no behaviour change intended here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018b7iqMBwoVkYzvYsnsAUKS