### PR TITLE
feat(observability): PSI-based NodeDiskIOSaturation for bare-metal hosts

### DIFF
--- a/clusters/production/apps/observability/kube-prometheus-stack-helmrelease.yaml
+++ b/clusters/production/apps/observability/kube-prometheus-stack-helmrelease.yaml
@@ -41,6 +41,11 @@ spec:
         # packed bare-metal PVE/PBS hosts (office-pve-amd sits at a steady ~91% by design, so the
         # upstream 90% default fired permanently), upstream 90% kept for k8s nodes.
         NodeMemoryHighUtilization: true
+        # Replaced by the two-tier rule in prometheusrule-node-disk.yaml. The Proxmox kernel charges
+        # ~1 request every 4-5 min a latency of (now - boot), so io_time_weighted — and therefore the
+        # upstream aqu-sq threshold — tracks uptime rather than I/O and fires permanently on the
+        # bare-metal hosts. Bare metal now alerts on PSI; k8s nodes keep the upstream aqu-sq rule.
+        NodeDiskIOSaturation: true
 
     alertmanager:
       enabled: true

--- a/clusters/production/apps/observability/kustomization.yaml
+++ b/clusters/production/apps/observability/kustomization.yaml
@@ -46,6 +46,10 @@ resources:
 # Two-tier NodeMemoryHighUtilization replacement (upstream rule disabled in the kps helmrelease):
 # 95% for bare-metal PVE/PBS hosts, upstream 90% for k8s nodes.
 - prometheusrule-node-memory.yaml
+# Two-tier NodeDiskIOSaturation replacement (upstream rule disabled in the kps helmrelease): PSI for
+# the bare-metal PVE/PBS hosts, whose kernel mis-accounts aqu-sq as a function of uptime; upstream
+# aqu-sq for k8s nodes.
+- prometheusrule-node-disk.yaml
 # Disk SMART health/wear from smartctl_exporter on the PVE hosts (scrape job in the helmrelease).
 - prometheusrule-smartctl.yaml
 # Edge security: CrowdSec (scrape jobs in the helmrelease, logs via fluent-bit -> Loki;

--- a/clusters/production/apps/observability/prometheusrule-node-disk.yaml
+++ b/clusters/production/apps/observability/prometheusrule-node-disk.yaml
@@ -1,0 +1,60 @@
+# Two-tier replacement for the upstream kube-prometheus-stack NodeDiskIOSaturation rule
+# (disabled in kube-prometheus-stack-helmrelease.yaml defaultRules.disabled):
+#  - PSI-based for the bare-metal PVE/PBS hosts, whose kernel mis-accounts the aqu-sq metric.
+#  - upstream aqu-sq > 10 kept for k8s nodes, whose guest kernels are unaffected.
+#
+# Why the bare-metal tier cannot use aqu-sq: the Proxmox kernel (seen on 7.0.14-6-pve and still
+# present on 7.0.14-11-pve) charges roughly one request every 4-5 minutes a latency of (now - boot),
+# so node_disk_io_time_weighted_seconds_total grows as a function of *uptime*, not of I/O, and the
+# upstream `> 10` threshold fires permanently. Proof, measured 2026-08-11 at ~2.6 d uptime:
+#   rate(node_disk_io_time_weighted_seconds_total[5m]) * 300 / (node_time_seconds - node_boot_time_seconds)
+# was 1.1104 on office-pve-amd nvme0n1 (NVMe) and 1.1110 on shuttle01 sdb (SATA) — identical to 4 s.f.
+# across unrelated hosts and disk technologies. At the same moment those disks were doing 2.85 MB/s at
+# 185 IOPS with node_disk_io_now = 0 and PSI io full at 0.8%, i.e. idle. The affected device is not
+# stable across reboots (nvme0n1 alone on 2026-08-06; both NVMes plus shuttle01 sdb on 2026-08-11), so
+# this cannot be narrowed with a device= exclusion. Because the magnitude scales with uptime, a freshly
+# rebooted host always looks clean — do not "verify a fix" shortly after a reboot; use the ratio above.
+#
+# PSI is derived from real task stall time and is immune to that accounting bug, so it is what the
+# bare-metal tier alerts on. Note PSI is per-host, not per-device: this tier has no `device` label.
+#
+# Tier selector: same discriminator as prometheusrule-node-memory.yaml — bare-metal series carry a
+# static `node` label and no `cluster` label; k8s DaemonSet targets have no `node` label and the
+# edge-sdr Pis carry cluster=edge-sdr (both land in the aqu-sq tier).
+# release=obs-kps so the operator ruleSelector picks it up.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: node-disk
+  labels:
+    release: obs-kps
+spec:
+  groups:
+  - name: node-disk
+    rules:
+    - alert: NodeDiskIOSaturation
+      # PSI "full" = fraction of wall time every non-idle task was stalled waiting on I/O. 0.30 means
+      # 30% of the last 15 minutes. Fleet baseline is well under 0.01 (nothing exceeded 0.05 across all
+      # five hosts on 2026-08-11), while a genuinely saturated disk pushes this toward 1.0.
+      expr: rate(node_pressure_io_stalled_seconds_total{job="node-exporter", node!="", cluster=""}[15m]) > 0.30
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Disk IO is stalling bare-metal host {{ $labels.node }}"
+        description: "Every non-idle task on {{ $labels.node }} has been stalled waiting on disk IO for {{ $value | humanizePercentage }} of the last 15 minutes. Bare-metal tier alerts on PSI, not aqu-sq, because the Proxmox kernel mis-accounts io_time_weighted — see the header of prometheusrule-node-disk.yaml. For per-guest attribution use the proxmox-guests Grafana dashboard (proxmox_vm_* from the native OTLP export), which also covers LXC CTs that node-exporter cannot see."
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodediskiosaturation
+    # `unless on (instance)` subtracts the bare-metal hosts matched by the PSI tier above, using the
+    # same marker series as prometheusrule-node-memory.yaml.
+    - alert: NodeDiskIOSaturation
+      expr: |-
+        (rate(node_disk_io_time_weighted_seconds_total{device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)",job="node-exporter"}[5m]) > 10)
+        unless on (instance)
+        node_memory_MemTotal_bytes{job="node-exporter", node!="", cluster=""}
+      for: 30m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Disk IO queue is high."
+        description: "Disk IO queue (aqu-sq) is high on {{ $labels.device }} at {{ $labels.instance }}, has been above 10 for the last 30 minutes, is currently at {{ printf \"%.2f\" $value }}.\nThis symptom might indicate disk saturation.\n"
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodediskiosaturation


### PR DESCRIPTION
## Problem

`NodeDiskIOSaturation` fires permanently on the PVE/PBS hosts. It is not measuring I/O.

The Proxmox kernel charges roughly one request every 4–5 minutes a latency of `(now - boot)`, so `node_disk_io_time_weighted_seconds_total` grows as a function of **uptime**, not disk activity. Measured 2026-08-11 at ~2.6 d uptime:

```
rate(node_disk_io_time_weighted_seconds_total[5m]) * 300 / uptime_seconds
  1.1104   office-pve-amd  nvme0n1  (NVMe)
  1.1110   shuttle01       sdb      (SATA)
```

Identical to four significant figures across unrelated hosts and disk technologies. At that moment the "saturated" disks were doing **2.85 MB/s at 185 IOPS**, with `node_disk_io_now = 0` and PSI io full at **0.8%**.

Present on `7.0.14-6-pve` and **still present on `7.0.14-11-pve`** — an earlier "fixed in -11" conclusion was drawn from a 90 s sample taken 36 min after a reboot, and the magnitude scales with uptime, so a fresh host always looks clean.

A `device=` exclusion is not viable: the affected device drifts. `nvme0n1` on 08-06 → both NVMes plus shuttle01 `sdb` earlier today → office-pve-amd `sdb` an hour later.

## Change

Mirrors the existing two-tier `NodeMemoryHighUtilization` treatment:

| Tier | Selector | Expression |
|---|---|---|
| Bare metal | `node!="", cluster=""` | `rate(node_pressure_io_stalled_seconds_total[15m]) > 0.30` for 15m |
| k8s nodes | everything else | upstream `aqu-sq > 10` for 30m, via `unless on (instance)` |

PSI is derived from real task stall time and is immune to the accounting bug. It is per-host, so the bare-metal tier carries no `device` label — device-level health on those hosts is already covered by `prometheusrule-smartctl.yaml`.

## Verification

Against live Prometheus:

- upstream expression alone → matches the phantom hosts
- with `unless on (instance)` → **empty** (bare metal correctly subtracted)
- PSI tier at 0.30 → **empty** (no false alarm)
- PSI selector → matches all five bare-metal hosts, baseline **0.005–0.017** vs the 0.30 threshold
- `PrometheusRule` passes `kubectl apply --server-side --dry-run=server` (operator validates rule syntax and annotation templates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018b7iqMBwoVkYzvYsnsAUKS